### PR TITLE
No need to get ursa outputs via base64, get buffers directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,10 +211,8 @@ function createClient(options) {
 
       function sendEncryptionKeyResponse() {
         var pubKey = mcPubKeyToURsa(packet.publicKey);
-        var encryptedSharedSecret = pubKey.encrypt(sharedSecret, 'binary', 'base64', ursa.RSA_PKCS1_PADDING);
-        var encryptedSharedSecretBuffer = new Buffer(encryptedSharedSecret, 'base64');
-        var encryptedVerifyToken = pubKey.encrypt(packet.verifyToken, 'binary', 'base64', ursa.RSA_PKCS1_PADDING);
-        var encryptedVerifyTokenBuffer = new Buffer(encryptedVerifyToken, 'base64');
+        var encryptedSharedSecretBuffer = pubKey.encrypt(sharedSecret, undefined, undefined, ursa.RSA_PKCS1_PADDING);
+        var encryptedVerifyTokenBuffer = pubKey.encrypt(packet.verifyToken, undefined, undefined, ursa.RSA_PKCS1_PADDING);
         client.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret);
         client.decipher = crypto.createDecipheriv('aes-128-cfb8', sharedSecret, sharedSecret);
         client.write(0xfc, {


### PR DESCRIPTION
Per the Ursa doc, the input encoding argument to pubKey.encrypt is ignored if the input is a buffer ; and if the second encoding is undefined, the output is already a buffer, so no need to get it as base64 just to decode it afterwards.
