### PR TITLE
Removed socket delays to reduce latency

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -22,6 +22,9 @@ Client.prototype.setSocket = function(socket) {
   var self = this;
   self.socket = socket;
   var incomingBuffer = new Buffer(0);
+
+  self.socket.setNoDelay();
+
   self.socket.on('data', function(data) {
     if (self.encryptionEnabled) data = new Buffer(self.decipher.update(data), 'binary');
     incomingBuffer = Buffer.concat([incomingBuffer, data]);

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,6 +23,8 @@ Server.prototype.listen = function(port, host) {
   var nextId = 0;
   self.socketServer = net.createServer();
   self.socketServer.on('connection', function(socket) {
+    socket.setNoDelay();
+
     var client = new Client(true);
     client._end = client.end;
     client.end = function end(endReason) {


### PR DESCRIPTION
It is pretty important not to use socket delays (Nagle algorithm) for game networking as it adds a lot of latency. By default, sockets wait (possibly up to a few hundred milliseconds) before writing data, so it can combine data into 1 packet.
