### PR TITLE
Support base64-encoded NBT data

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1033,6 +1033,8 @@ function readSlot(buffer, offset) {
 
 function SlotWriter(value) {
   this.value = value;
+  if(typeof this.value.nbtData === 'string')
+    this.value.nbtData = new Buffer(this.value.nbtData, 'base64');
   this.size = value.id === -1 ? 2 : 7 + this.value.nbtData.length;
 }
 


### PR DESCRIPTION
I simply made the SlotWriter convert base64-strings to buffers for the NBT data field.
