### PR TITLE
Fixed bug where the wrong type was used when serializing entityMetadata

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -534,7 +534,7 @@ var entityMetadataTypes = {
   3: 'float',
   4: 'string',
   5: 'slot',
-  6: 'intVector',
+  6: 'intVector'
 };
 
 // maps string type name to number
@@ -555,7 +555,8 @@ function sizeOfEntityMetadata(value) {
 
 function writeEntityMetadata(value, buffer, offset) {
   value.forEach(function(item) {
-    var headerByte = (item.type << 5) | item.key;
+    var type = entityMetadataTypeBytes[item.type];
+    var headerByte = (type << 5) | item.key;
     buffer.writeUInt8(headerByte, offset);
     offset += 1;
     offset = types[item.type][1](item.value, buffer, offset);


### PR DESCRIPTION
This fixes a pretty big bug that made writing entityMetadata not work properly.
