### PR TITLE
Fix packet 0xce, "create" should be a byte. 

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -433,7 +433,7 @@ var packets = {
   0xce: [
     { name: "name", type: "string" },
     { name: "displayText", type: "string" },
-    { name: "create", type: "bool" }
+    { name: "action", type: "byte" }
   ],
   0xcf: [
     { name: "itemName", type: "string" },


### PR DESCRIPTION
Renamed "create" to "action", and made it a byte. 
According to wiki.vg, 0 is create, 1 to remove, and 2 to update.
