### PR TITLE
Connect to a server's SRV record if they specify one

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,13 +70,17 @@ Client.prototype.setSocket = function(socket) {
 
 Client.prototype.connect = function(port, host) {
   var self = this;
-  dns.resolveSrv("_minecraft._tcp." + host, function(err, addresses) {
-    if (addresses) {
-      self.setSocket(net.connect(addresses[0].port, addresses[0].name));
-    } else {
-      self.setSocket(net.connect(port, host));
-    }
-  });
+  if (port == 25565) {
+      dns.resolveSrv("_minecraft._tcp." + host, function(err, addresses) {
+      if (addresses) {
+        self.setSocket(net.connect(addresses[0].port, addresses[0].name));
+      } else {
+        self.setSocket(net.connect(port, host));
+      }
+    });  
+  } else {
+    self.setSocket(net.connect(port, host));
+  }
 };
 
 Client.prototype.end = function(reason) {


### PR DESCRIPTION
Quick change to resolve SRV records in-library instead of requiring clients using the library to resolve them.
