### PR TITLE
New way to handle conditional fields in packets

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1450,8 +1450,10 @@ function parsePacket(buffer, isServer) {
   for (i = 0; i < packetInfo.length; ++i) {
     fieldInfo = packetInfo[i];
     var condition = fieldInfo.condition;
-    if (typeof condition != "undefined" && !condition(results))
+    if (typeof condition != "undefined" && !condition(results)) {
+      results[fieldInfo.name] = null;
       continue;
+    }
     readResults = readPacketField(fieldInfo);
     if (!readResults || readResults.error) {
       return readResults;


### PR DESCRIPTION
Some packets have conditional fields. The previous way to handle
those was to provide a single condition for each packet type
which determined if additional fields are appended to the packet.
Unfortunately this is not enough for some packets: They have
complex conditions that cannot be expressed this way.

This diff changes the way conditional fields are handled: For
each field in each packet there is a new optional 'condition'
function which will be called with the packet data. Only if
the 'condition' function returns true, the field is de/encoded.

This diff also adds new (previously missing) conditions.
