### PR TITLE
Add writeRaw() and option to receive raw, unparsed packet fields

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,7 @@ function Client(isServer) {
   this.isServer = !!isServer;
   this.socket = null;
   this.encryptionEnabled = false;
+  this.shouldParsePayload = true;
   this.cipher = null;
   this.decipher = null;
 }
@@ -42,7 +43,7 @@ Client.prototype.setSocket = function(socket) {
     incomingBuffer = Buffer.concat([incomingBuffer, data]);
     var parsed, packet;
     while (true) {
-      parsed = parsePacket(incomingBuffer, self.state, self.isServer);
+      parsed = parsePacket(incomingBuffer, self.state, self.isServer, self.shouldParsePayload);
       if (! parsed) break;
       if (parsed.error) {
           this.emit('error', parsed.error);
@@ -112,7 +113,14 @@ Client.prototype.write = function(packetId, params) {
   var buffer = createPacketBuffer(packetId, this.state, params, this.isServer);
   debug("writing packetId " + packetId + " (0x" + packetId.toString(16) + ")");
   debug(params);
-  var out = this.encryptionEnabled ? new Buffer(this.cipher.update(buffer), 'binary') : buffer;
-  this.socket.write(out);
+  this.writeRaw(buffer, true);
   return true;
 };
+
+Client.prototype.writeRaw = function(buffer, shouldEncrypt) {
+  if (shouldEncrypt == null) shouldEncrypt = true;
+
+  var out = (shouldEncrypt && this.encryptionEnabled) ? new Buffer(this.cipher.update(buffer), 'binary') : buffer;
+  this.socket.write(out);
+};
+

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1602,7 +1602,8 @@ function createPacketBuffer(packetId, state, params, isServer) {
   return buffer;
 }
 
-function parsePacket(buffer, state, isServer) {
+function parsePacket(buffer, state, isServer, shouldParsePayload) {
+  if (shouldParsePayload == null) shouldParsePayload = true;
   var cursor = 0;
   var lengthField = readVarInt(buffer, 0);
   if (!!!lengthField) return null;
@@ -1615,7 +1616,15 @@ function parsePacket(buffer, state, isServer) {
   var packetId = packetIdField.value;
   cursor += packetIdField.size;
 
-  return parsePayload(packetId, state, isServer, buffer, cursor, length, lengthField.size);
+  if (shouldParsePayload)
+    return parsePayload(packetId, state, isServer, buffer, cursor, length, lengthField.size);
+  else
+    return { 
+      size: length + lengthField.size, 
+      results: {
+        raw: buffer
+      }
+    };
 }
 
 function parsePayload(packetId, state, isServer, buffer, cursor, length, payloadSize) {


### PR DESCRIPTION
Adds two new features:
- `writeRaw(buffer, shouldEncrypt)`: allows you to write raw packet buffers, instead of having `write(packetId, params)` encode the packet. Better than client.socket.write() since it will encrypt the packet for you if encryption is enabled (unless the shouldEncrypt argument is false; default true)
- client `this.shouldParsePayload`: if false (default true), then incoming packet payloads will not be parsed. Only the header will be parsed, and instead of parsed fields you'll get back "raw" set to the raw undecoded packet. The application can alter this flag at any time to change the parsing behavior (for example, it could be set in an event handler for login_success, after the handshaking has completed and the server is ready to pass through raw packets).

Both are mainly useful for proxies, where the proxy does not need or have full knowledge of each packet payload (using these changes in a WebSocket<->Minecraft proxy: https://github.com/deathcap/wsmc)
