### PR TITLE
[WIP] Array and Container type, general protocol.js cleanup

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -47,9 +47,9 @@ var packets = {
       0x01: [
         { name: "serverId", type: "string" },
         { name: "countPublicKey", type: "short" },
-        { name: "publicKey", type: "byte", count: "countPublicKey" },
+        { name: "publicKey", type: "buffer", count: "countPublicKey" },
         { name: "countVerifyToken", type: "short" },
-        { name: "verifyToken", type: "byte", count: "countVerifyToken" }
+        { name: "verifyToken", type: "buffer", count: "countVerifyToken" }
       ],
       0x02: [
         { name: "uuid", type: "string" },
@@ -62,9 +62,9 @@ var packets = {
       ],
       0x01: [
         { name: "countSharedSecret", type: "short" },
-        { name: "sharedSecret", type: "byte", count: "countSharedSecret" },
+        { name: "sharedSecret", type: "buffer", count: "countSharedSecret" },
         { name: "countVerifyToken", type: "short" },
-        { name: "verifyToken", type: "byte", count: "countVerifyToken" }
+        { name: "verifyToken", type: "buffer", count: "countVerifyToken" }
       ]
     }
   },
@@ -182,7 +182,7 @@ var packets = {
         { name: "x", type: "int" },
         { name: "y", type: "int" },
         { name: "z", type: "int" },
-        { name: "count", type: "short" }
+        { name: "count", type: "array", arrayType: "short" }
       ],
       0x12: [
         { name: "entityId", type: "int" },
@@ -192,7 +192,7 @@ var packets = {
       ],
       0x13: [
         { name: "count", type: "byte" },
-        { name: "entityIds", type: "int", count: "count" }
+        { name: "entityIds", type: "array", arrayType: "int", count: "count" }
       ],
       0x14: [
         { name: "entityId", type: "int" } 
@@ -259,11 +259,11 @@ var packets = {
       0x20: [
         { name: "entityId", type: "int" },
         { name: "count", type: "int" },
-        { name: "properties", type: "container", count: "count", contents: [
+        { name: "properties", type: "array", arrayType: "container", count: "count", contents: [
           { name: "key", type: "string" },
           { name: "value", type: "double" },
           { name: "listLength", type: "short" },
-          { name: "modifiers", type: "container", count: "listLength", contents: [
+          { name: "modifiers", type: "array", arrayType: "container", count: "listLength", contents: [
             { name: "uuid", type: "UUID" },
             { name: "amount", type: "double" },
             { name: "operation", type: "byte" }
@@ -277,7 +277,7 @@ var packets = {
         { name: "bitMap", type: "ushort" },
         { name: "addBitMap", type: "ushort" },
         { name: "compressedSize", type: "int" },
-        { name: "compressedChunkData", type: "byte", count: "compressedSize" }
+        { name: "compressedChunkData", type: "buffer", count: "compressedSize" }
       ],
       0x22: [
         { name: "chunkX", type: "int" },
@@ -312,8 +312,8 @@ var packets = {
         { name: "columnCount", type: "short" },
         { name: "dataLength", type: "int" },
         { name: "skyLight", type: "bool" },
-        { name: "chunkData", type: "byte", count: "dataLength" },
-        { name: "meta", type: "container", count: "columnCount", contents: [
+        { name: "chunkData", type: "buffer", count: "dataLength" },
+        { name: "meta", type: "array", arrayType: "container", count: "columnCount", contents: [
           { name: "chunkX", type: "int" },
           { name: "chunkZ", type: "int" },
           { name: "bitMap", type: "ushort" },
@@ -326,7 +326,7 @@ var packets = {
         { name: "z", type: "float" },
         { name: "radius", type: "float" },
         { name: "recordCount", type: "int" },
-        { name: "affectedBlockOffsets", type: "container", count: "recordCount", contents: [
+        { name: "affectedBlockOffsets", type: "array", arrayType: "container", count: "recordCount", contents: [
           { name: "x", type: "byte" },
           { name: "y", type: "byte" },
           { name: "z", type: "byte" }
@@ -394,7 +394,7 @@ var packets = {
       0x30: [
         { name: "windowId", type: "ubyte" },
         { name: "count", type: "short" },
-        { name: "items", type: "slot", count: "count" }
+        { name: "items", type: "array", arrayType: "slot", count: "count" }
       ],
       0x31: [
         { name: "windowId", type: "ubyte" },
@@ -418,7 +418,7 @@ var packets = {
       0x34: [
         { name: "itemDamage", type: "varint" },
         { name: "dataLength", type: "short" },
-        { name: "data", type: "byte", count: "dataLength" }
+        { name: "data", type: "buffer", count: "dataLength" }
       ],
       0x35: [
         { name: "x", type: "int" },
@@ -426,7 +426,7 @@ var packets = {
         { name: "z", type: "int" },
         { name: "action", type: "ubyte" },
         { name: "nbtDataLength", type: "short" },
-        { name: "nbtData", type: "byte", count: "nbtDataLength" }
+        { name: "nbtData", type: "buffer", count: "nbtDataLength" }
       ],
       0x36: [
         { name: "x", type: "int" },
@@ -435,7 +435,7 @@ var packets = {
       ],
       0x37: [
         { name: "count", type: "varint" },
-        { name: "entry", type: "container", count: "count", contents: [
+        { name: "entry", type: "array", arrayType: "container", count: "count", contents: [
           { name: "name", type: "string" },
           { name: "value", type: "varint" }
         ]}
@@ -452,7 +452,7 @@ var packets = {
       ],
       0x3A: [
         { name: "count", type: "varint" },
-        { name: "matches", type: "string", count: "count" }
+        { name: "matches", type: "array", arrayType: "string", count: "count" }
       ],
       0x3B: [
         { name: "name", type: "string" },
@@ -488,13 +488,13 @@ var packets = {
           return field_values['mode'] == 0 || field_values['mode'] == 3 || field_values['mode'] == 4;
         }, contents: [
           { name: "playerCount", type: "short" },
-          { name: "players", type: "string", count: "playerCount" }
+          { name: "players", type: "array", arrayType: "string", count: "playerCount" }
         ] }
       ],
       0x3F: [
         { name: "channel", type: "string" },
         { name: "dataLength", type: "short" },
-        { name: "data", type: "byte", count: "dataLength" }
+        { name: "data", type: "buffer", count: "dataLength" }
       ],
       0x40: [
         { name: "reason", type: "string" }
@@ -625,31 +625,32 @@ var packets = {
       0x17: [
         { name: "channel", type: "string" },
         { name: "dataLength", type: "short" },
-        { name: "data", type: "byte", count: "dataLength" }
+        { name: "data", type: "buffer", count: "dataLength" }
       ],
     }
   }
 };
 
 var types = {
-  'int': [readInt, writeInt, 4],
-  'short': [readShort, writeShort, 2],
-  'ushort': [readUShort, writeUShort, 2],
   'byte': [readByte, writeByte, 1],
   'ubyte': [readUByte, writeUByte, 1],
+  'short': [readShort, writeShort, 2],
+  'ushort': [readUShort, writeUShort, 2],
+  'int': [readInt, writeInt, 4],
+  'double': [readDouble, writeDouble, 8],
+  'float': [readFloat, writeFloat, 4],
+  'long': [readLong, writeLong, 8],
+  'varint': [readVarInt, writeVarInt, sizeOfVarInt],
   'string': [readString, writeString, sizeOfString],
   'ustring': [readString, writeString, sizeOfUString],
   'bool': [readBool, writeBool, 1],
-  'double': [readDouble, writeDouble, 8],
-  'float': [readFloat, writeFloat, 4],
   'slot': [readSlot, writeSlot, sizeOfSlot],
-  'long': [readLong, writeLong, 8],
-  'varint': [readVarInt, writeVarInt, sizeOfVarInt],
-  'ascii': [readAscii, writeAscii, sizeOfAscii],
   'entityMetadata': [readEntityMetadata, writeEntityMetadata, sizeOfEntityMetadata],
   'objectData': [readObjectData, writeObjectData, sizeOfObjectData],
-  'container': [readContainer, writeContainer, sizeOfContainer],
   'UUID': [readUUID, writeUUID, 16],
+  'container': [readContainer, writeContainer, sizeOfContainer],
+  'buffer': [readBuffer, writeBuffer, sizeOfBuffer],
+  'array': [readArray, writeArray, sizeOfArray]
 };
 
 var debug;
@@ -820,37 +821,6 @@ function readUUID(buffer, offset) {
       buffer.readInt32BE(offset + 12),
     ],
     size: 16,
-  };
-}
-
-function sizeOfAscii(value) {
-  return 2 + value.length;
-}
-
-function writeAscii(value, buffer, offset) {
-  buffer.writeInt16BE(value.length, offset);
-  offset += 2;
-
-  for (var i = 0; i < value.length; ++i) {
-    buffer.writeUInt8(value.charCodeAt(i), offset);
-    offset += 1;
-  }
-  return offset;
-}
-
-function readAscii (buffer, offset) {
-  var results = readShort(buffer, offset);
-  if (! results) return null;
-
-  var strBegin = offset + results.size;
-  var strLen = results.value;
-  var strEnd = strBegin + strLen;
-  if (strEnd > buffer.length) return null;
-  var str = buffer.slice(strBegin, strEnd).toString('ascii');
-
-  return {
-    value: str,
-    size: strEnd - offset,
   };
 }
 
@@ -1106,7 +1076,7 @@ function readVarInt(buffer, offset) {
 
 function sizeOfContainer(value, fieldInfo) {
   return fieldInfo.contents.reduce(function(size, subFieldInfo) {
-    return size += sizeOf(subFieldInfo.type, value[subFieldInfo.name], fieldInfo.contents, subFieldInfo);
+    return size += sizeOf(subFieldInfo, value);
   }, 0);
 }
 
@@ -1135,6 +1105,68 @@ function readContainer(buffer, offset, fieldInfo, results) {
   return results;
 }
 
+function sizeOfBuffer(value) {
+  return value.length;
+}
+
+function writeBuffer(value, buffer, offset) {
+  value.copy(buffer, offset);
+  return offset + value.length;
+}
+
+function readBuffer(buffer, offset, fieldInfo, results) {
+  return {
+    size: results[fieldInfo.count],
+    value: buffer.slice(offset, offset + results[fieldInfo.count])
+  };
+}
+
+function sizeOfArray(value, fieldInfo) {
+  return value.reduce(function(size, value) {
+    var fakeFieldInfo = {
+      name: fieldInfo.name,
+      type: fieldInfo.arrayType,
+      contents: fieldInfo.contents,
+      count: fieldInfo.count
+    };
+    var f
+    return size += sizeOf(fakeFieldInfo, value);
+  }, 0);
+}
+
+function writeArray(values, buffer, offset, packetInfo, fieldInfo) {
+  var fakeFieldInfo = {
+    name: fieldInfo.name,
+    type: fieldInfo.arrayType,
+    contents: fieldInfo.contents
+  }
+  var fakeParams = {};
+  for (var value in values) {
+    fakeParams[fakeFieldInfo.name] = value;
+    offset = write(fakeFieldInfo, fakeParams, buffer, offset, packetInfo, []);
+  }
+  return offset;
+}
+
+function readArray(buffer, offset, fieldInfo, results) {
+  var counts = results[fieldInfo.count];
+  var returnResults = {
+    value: [],
+    size: 0
+  }
+  var fakeFieldInfo = {
+    name: fieldInfo.name,
+    type: fieldInfo.arrayType,
+    contents: fieldInfo.contents
+  }
+  for (var i = 0;i < counts;i++) {
+    var tmp = read(fakeFieldInfo, buffer, offset, results);
+    returnResults.size += tmp.size;
+    returnResults.value[i] = tmp.value;
+  }
+  return returnResults;
+}
+
 function get(packetId, state, toServer) {
   var direction = toServer ? "toServer" : "toClient";
   var packetInfo = packets[state][direction][packetId];
@@ -1152,23 +1184,12 @@ function sizeOf(fieldInfo, params) {
   var dataType = types[fieldInfo.type];
   assert.ok(dataType, "unknown data type " + fieldInfo.type);
   var value = params[fieldInfo.name];
-  var count = 1;
-
-  if ('count' in fieldInfo) {
-    count = value.length;
-  } else {
-    value = [value];
-  }
 
   var dataSize = dataType[2];
   if (typeof dataSize === "function") {
-    var size = 0;
-    for (var i = 0;i < count;i++) {
-      size += dataSize(value[i], fieldInfo);
-    }
-    return size;
+    return dataSize(value, fieldInfo);
   } else {
-    return dataSize * count;
+    return dataSize;
   }
 }
 
@@ -1181,26 +1202,10 @@ function write(fieldInfo, params, buffer, offset, packetInfo, counters) {
   assert.ok(dataType, "unknown data type " + fieldInfo.type);
   
   var value = params[fieldInfo.name];
-  if ('count' in fieldInfo) {
-    var newFieldInfo = {
-      type: fieldInfo.type,
-      name: fieldInfo.name,
-      contents: fieldInfo.contents
-    };
-    if (fieldInfo.type === "byte") {
-      value.copy(buffer, offset);
-      offset += value.length;
-    } else {
-      for (var i = 0;i < value.length; i++) {
-        offset = write(newFieldInfo, value[i], buffer, offset, packetInfo, counters);
-      }
-    }
+  if (fieldInfo.name in counters) {
+    offset = dataType[1](params[counters[fieldInfo.name]].length, buffer, offset, packetInfo, fieldInfo);
   } else {
-    if (fieldInfo.name in counters) {
-      offset = dataType[1](params[counters[fieldInfo.name]].length, buffer, offset, packetInfo, fieldInfo);
-    } else {
-      offset = dataType[1](value, buffer, offset, packetInfo, fieldInfo);
-    }
+    offset = dataType[1](value, buffer, offset, packetInfo, fieldInfo);
   }
   return offset;
 }
@@ -1211,33 +1216,9 @@ function read(fieldInfo, buffer, offset, results) {
       size: 0
     };
   }
-  if ('count' in fieldInfo) {
-    var newFieldInfo = {
-      type: fieldInfo.type,
-      name: fieldInfo.name,
-      contents: fieldInfo.contents
-    };
-    var readResults = {
-      value: new Array(results[fieldInfo.count]),
-      size: 0
-    };
-    if (fieldInfo.type === "byte") {
-      readResults.value = buffer.slice(offset, offset + results[fieldInfo.count]);
-      readResults.size += results[fieldInfo.count];
-    } else {
-      for (var i = 0;i < results[fieldInfo.count];i++) {
-        var subRead = read(newFieldInfo, buffer, offset, results);
-        readResults.size += subRead.size;
-        offset += subRead.size;
-        readResults.value[i] = subRead.value;
-      }
-    }
-    return readResults;
-  } else {
-    var dataType = types[fieldInfo.type];
-    assert.ok(dataType, "unknown data type " + fieldInfo.type);  
-    return dataType[0](buffer, offset, fieldInfo, results);
-  }
+  var dataType = types[fieldInfo.type];
+  assert.ok(dataType, "unknown data type " + fieldInfo.type);  
+  return dataType[0](buffer, offset, fieldInfo, results);
 }
 
 function createPacketBuffer(packetId, state, params, isServer) {


### PR DESCRIPTION
WIP, still have to fix the test cases, and I don't like how some things currently are. 
### The Issue:

We have a plethora of array types (byteArray16, byteArray8, slotArray) and container types (intVector, byteVector, mapChunkBulk), with only more getting added after each update, that make the protocol.js harder to read, understand and maintain. 

Also, the protocol is kinda messy. This PR puts the read, write and sizeof of the same type together. 
### Justification for this PR:

This creates three simple, convenient types (array, buffer, container) that replaces the current array and container types thanks to a simple, extensible system.
### PR Breakdown
-   Array : arrays have a "count" field, a string that points to another field in the packet. This field represents the array's length. They also have a "arrayType" field, which tells us what type the array's contents are. arrayType must be a valid type from the "types" object. Example : 

``` javascript
"toClient/0x30": [
  { name: "windowId", type: "ubyte" },
  { name: "count", type: "short" },
  { name: "items", type: "array", arrayType: "slot", count: "count" }
]
```
- Buffer : buffers acts exactly like array, except they don't have an "arrayType". They read/write nodejs buffers. Example : 

``` javascript
"serverBound/0x01": [
  { name: "countSharedSecret", type: "short" },
  { name: "sharedSecret", type: "buffer", count: "countSharedSecret" },
  { name: "countVerifyToken", type: "short" },
  { name: "verifyToken", type: "buffer", count: "countVerifyToken" }
]
```
- Container : Container have a "contents" field, representing the contents of the container in the same format as a packet.

``` javascript
0x20: [
  { name: "entityId", type: "int" },
  { name: "count", type: "int" },
  { name: "properties", type: "array", arrayType: "container", count: "count", contents: [
    { name: "key", type: "string" },
    { name: "value", type: "double" },
    { name: "listLength", type: "short" },
    { name: "modifiers", type: "array", arrayType: "container", count: "listLength", contents: [
      { name: "uuid", type: "UUID" },
      { name: "amount", type: "double" },
      { name: "operation", type: "byte" },
    ]}
  ]}
],
```
### Caveats:

Right now, count field has to be a variable within the same "container" as the array it represents.
### Notes :

Having a nodejs script that'd generate a documentation of the packets out of the protocol.js would be cool. Right now I think the biggest caveat with node-minecraft-protocol is having to check the protocol.js to find out the fields name for the packet. Having a single html page, following more-or-less the same "layout" as http://wiki.vg/Protocol , but without own field names, would speed up looking up those fields.
