### PR TITLE
Fix infinite loop in client_echo example

### DIFF
--- a/examples/client_echo.js
+++ b/examples/client_echo.js
@@ -11,7 +11,7 @@ client.on('connect', function() {
 client.on([states.PLAY, 0x02], function(packet) {
   var jsonMsg = JSON.parse(packet.message);
   if (jsonMsg.translate == 'chat.type.announcement' || jsonMsg.translate == 'chat.type.text') {
-    var username = jsonMsg.with[0];
+    var username = jsonMsg.with[0]['clickEvent']['value'].split(' ')[1];
     var msg = jsonMsg.with[1];
     if (username === client.username) return;
     client.write(0x01, {message: msg});


### PR DESCRIPTION
Previously username was an object that contained the message that the server sent the client. When JavaScript checked to see if username (an object) === client.username (a string) it always returned false, thus entering into an infinite loop as the chat client responded to itself indefinitely. This patch addresses by parsing out the username from the object.
