### PR TITLE
fix chat problem with multi-byte characters

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -470,7 +470,7 @@ var packets = {
       ],
       0x02: [
         { name: "target", type: "int" },
-        { name: "leftClick", type: "byte" }
+        { name: "mouse", type: "byte" }
       ],
       0x03: [
         { name: "onGround", type: "bool" }
@@ -1352,19 +1352,22 @@ function writeSlot(value, buffer, offset) {
 }
 
 function sizeOfString(value) {
-  assert.ok(value.length < STRING_MAX_LENGTH, "string greater than max length");
-  return sizeOfVarInt(value.length) + value.length;
+  var length = Buffer.byteLength(value, 'utf8');
+  assert.ok(length < STRING_MAX_LENGTH, "string greater than max length");
+  return sizeOfVarInt(length) + length;
 }
 
 function sizeOfUString(value) {
-  assert.ok(value.length < SRV_STRING_MAX_LENGTH, "string greater than max length");
-  return sizeOfVarInt(value.length) + value.length;
+  var length = Buffer.byteLength(value, 'utf8');
+  assert.ok(length < SRV_STRING_MAX_LENGTH, "string greater than max length");
+  return sizeOfVarInt(length) + length;
 }
 
 function writeString(value, buffer, offset) {
-  offset = writeVarInt(value.length, buffer, offset);
-  buffer.write(value, offset, value.length, 'utf8');
-  return offset + value.length;
+  var length = Buffer.byteLength(value, 'utf8');
+  offset = writeVarInt(length, buffer, offset);
+  buffer.write(value, offset, length, 'utf8');
+  return offset + length;
 }
 
 function sizeOfAscii(value) {


### PR DESCRIPTION
fix the problem that wrong length used when sending strings

also modify some packet variable name
