### PR TITLE
Emit a 'raw' event for all raw buffers (in addition to per-packet-type)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -95,6 +95,7 @@ Client.prototype.setSocket = function(socket) {
       self.emit(packetName, packet);
       self.emit('packet', packet);
       self.emit('raw.' + packetName, parsed.buffer);
+      self.emit('raw', parsed.buffer);
     }
   });
 


### PR DESCRIPTION
With https://github.com/andrewrk/node-minecraft-protocol/pull/72 my use case was receiving all raw packet data so it could be proxied as-is, but https://github.com/andrewrk/node-minecraft-protocol/pull/80 added a new event type for each packet type:

```
   self.emit('raw.' + packetName, parsed.buffer);
```

which is makes this task difficult (would have to iterate each packet type, add listeners for each, unless I'm missing something…). So with this PR I added a bare 'raw' event, which is emitted for all packets regardless of their type:

```
   self.emit('raw', parsed.buffer);
```
