### PR TITLE
Fix team scoreboard

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1218,7 +1218,7 @@ function read(buffer, cursor, fieldInfo, rootNodes) {
 
 function write(value, buffer, offset, fieldInfo, rootNode) {
   if (fieldInfo.condition && !fieldInfo.condition(rootNode)) {
-    return null;
+    return offset;
   }
   var type = types[fieldInfo.type];
   if (!type) {


### PR DESCRIPTION
Because the team scoreboard values are optional, they should not always be included in the written response.
