### PR TITLE
Fix Spawn Object Packet Parsing

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1101,6 +1101,7 @@ function readContainer(buffer, offset, typeArgs, rootNode) {
     rootNode.this = results.value;
     for (var index in typeArgs.fields) {
         var readResults = read(buffer, offset, typeArgs.fields[index], rootNode);
+        if (readResults == null) { continue; }
         results.size += readResults.size;
         offset += readResults.size;
         results.value[typeArgs.fields[index].name] = readResults.value;


### PR DESCRIPTION
If read fails a pre-condition within a container, skip it
