### PR TITLE
Update yggdrasil.js to fix bug

### DIFF
--- a/lib/yggdrasil.js
+++ b/lib/yggdrasil.js
@@ -20,7 +20,8 @@ function getSession(username, password, clientToken, refresh, cb) {
           var session = {
             accessToken: resp.body.accessToken,
             clientToken: resp.body.clientToken,
-            username: resp.body.selectedProfile.name
+            username: resp.body.selectedProfile.name,
+            selectedProfile: resp.body.selectedProfile
           };
           cb(null, session);
         } else {


### PR DESCRIPTION
![popucf9](https://cloud.githubusercontent.com/assets/3320430/5154244/314f9da8-728b-11e4-8d38-d934ad6a5017.png)

This fixes a crash that occurs on line 310 of index.js where it tries to read the value of client.session.selectedProfile.id which doesn't exist if the session was acquired by a refresh with old auth details.
