### PR TITLE
Don't write out packets if connection is ended

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,10 +143,14 @@ Client.prototype.connect = function(port, host) {
 
 Client.prototype.end = function(reason) {
   this._endReason = reason;
+  this.ended = true;
   this.socket.end();
 };
 
 Client.prototype.write = function(packetId, params) {
+  if(this.ended) {
+    return false;
+  }
   if (Array.isArray(packetId)) {
      if (packetId[0] !== this.state)
       return false;
@@ -162,6 +166,9 @@ Client.prototype.write = function(packetId, params) {
 };
 
 Client.prototype.writeRaw = function(buffer, shouldEncrypt) {
+    if(this.ended) {
+      return false;
+    }
     if (shouldEncrypt === null) {
         shouldEncrypt = true;
     }


### PR DESCRIPTION
Don't write out packets if connection is ended, and mark as ended on end method