### PR TITLE
Expose the Client class to browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,5 @@
 
 module.exports = {
+  Client: require('./dist/client'),
   protocol: require('./dist/protocol')
 };

--- a/src/client.js
+++ b/src/client.js
@@ -1,8 +1,6 @@
-var net = require('net')
-  , EventEmitter = require('events').EventEmitter
+var EventEmitter = require('events').EventEmitter
   , util = require('util')
   , protocol = require('./protocol')
-  , dns = require('dns')
   , createPacketBuffer = protocol.createPacketBuffer
   , compressPacketBuffer = protocol.compressPacketBuffer
   , oldStylePacket = protocol.oldStylePacket
@@ -149,21 +147,6 @@ Client.prototype.setSocket = function(socket) {
     self.socket.removeListener('end', endSocket);
     self.socket.removeListener('timeout', endSocket);
     self.emit('end', self._endReason);
-  }
-};
-
-Client.prototype.connect = function(port, host) {
-  var self = this;
-  if (port == 25565 && net.isIP(host) === 0) {
-    dns.resolveSrv("_minecraft._tcp." + host, function(err, addresses) {
-    if (addresses && addresses.length > 0) {
-      self.setSocket(net.connect(addresses[0].port, addresses[0].name));
-    } else {
-      self.setSocket(net.connect(port, host));
-    }
-    });
-  } else {
-    self.setSocket(net.connect(port, host));
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ var EventEmitter = require('events').EventEmitter
         , superagent = require('superagent')
         , protocol = require('./protocol')
         , Client = require('./client')
+        , dns = require('dns')
+        , net = require('net')
         , Server = require('./server')
         , Yggdrasil = require('./yggdrasil.js')
         , getSession = Yggdrasil.getSession
@@ -227,6 +229,21 @@ function createServer(options) {
   server.listen(port, host);
   return server;
 }
+
+Client.prototype.connect = function(port, host) {
+  var self = this;
+  if (port == 25565 && net.isIP(host) === 0) {
+    dns.resolveSrv("_minecraft._tcp." + host, function(err, addresses) {
+    if (addresses && addresses.length > 0) {
+      self.setSocket(net.connect(addresses[0].port, addresses[0].name));
+    } else {
+      self.setSocket(net.connect(port, host));
+    }
+    });
+  } else {
+    self.setSocket(net.connect(port, host));
+  }
+};
 
 function createClient(options) {
   assert.ok(options, "options is required");


### PR DESCRIPTION
https://github.com/PrismarineJS/node-minecraft-protocol/pull/71 added support for browserify by overriding index.js with a browserify-specific browser.js exposing only the `protocol` submodule, a subset of node-minecraft-protocol that works well in web browsers. This PR additionally exposes the `Client` class, which is also browserifiable (I am using it in https://github.com/deathcap/wsmc, previously as require('minecraft-protocol/lib/client') until GH-136; cleaner to expose on the default export anyways). 

For comparison here's the exports from the (non-browser) dist/index.js:

```javascript
module.exports = {
  createClient: createClient,
  createServer: createServer,
  Client: Client,
  Server: Server,
  ping: require("./ping"),
  protocol: protocol,
  yggdrasil: Yggdrasil };
```

and the updated browser.js:

```javascript
 module.exports = {
  Client: require('./dist/client'),
   protocol: require('./dist/protocol')
 };
```

createServer and createClient use ursa so cannot currently be exposed in the browser (despite ursa-purejs — but out of scope of this issue), yggdrasil uses a third-party authentication server so it cannot be used either (without, e.g., a CORS proxy, or replacing with OAuth, etc.), Server and ping might work but haven't tested (if they do, can be exposed later if needed), but both `protocol` and `Client` definitely work so can be safely exported here.