### PR TITLE
Add circle ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join the chat at https://gitter.im/PrismarineJS/node-minecraft-protocol](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PrismarineJS/node-minecraft-protocol?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[![Build Status](https://circleci.com/gh/PrismarineJS/node-minecraft-protocol.png?style=shield)](https://circleci.com/gh/PrismarineJS/node-minecraft-protocol)
+
 Parse and serialize minecraft packets, plus authentication and encryption.
 
 ## Features


### PR DESCRIPTION
fix #133 

It would be better to add a circle-token=:circle-token in the image url so that everybody can see the image (see https://circleci.com/docs/status-badges#access-control)