### PR TITLE
emit error instead of throwing when write callback gives an error

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -156,12 +156,9 @@ Client.prototype.end = function(reason) {
   this.socket.end();
 };
 
-function noop(err) {
-  if(err) throw err;
-}
-
 Client.prototype.write = function(packetId, params, cb) {
-  cb = cb || noop;
+  var self=this;
+  cb = cb || function(err){if(err) {self.emit('error',err);}};
   if(Array.isArray(packetId)) {
     if(packetId[0] !== this.state)
       return false;
@@ -174,7 +171,8 @@ Client.prototype.write = function(packetId, params, cb) {
   var finishWriting = function(err, buffer) {
     if(err) {
       console.log(err);
-      throw err; // TODO : Handle errors gracefully, if possible
+      cb(err);
+      return;
     }
     var packetName = packetNames[that.state][that.isServer ? "toClient" : "toServer"][packetId];
     debug("writing packetId " + that.state + "." + packetName + " (0x" + packetId.toString(16) + ")");

--- a/src/index.js
+++ b/src/index.js
@@ -126,8 +126,10 @@ function createServer(options) {
 
       client.once([states.STATUS, 0x01], function(packet) {
         client.write(0x01, {time: packet.time},function(err){
-          if(err)
-            throw err;
+          if(err) {
+            client.emit('error',err);
+            return;
+          }
           client.end();
         });
       });
@@ -218,8 +220,10 @@ function createServer(options) {
       //client.write('compress', { threshold: 256 }); // Default threshold is 256
       //client.compressionThreshold = 256;
       client.write(0x02, {uuid: client.uuid, username: client.username},function(err){
-        if(err)
-          throw err;
+        if(err) {
+          client.emit('error',err);
+          return;
+        }
         client.state = states.PLAY;
         loggedIn = true;
         startKeepAlive();
@@ -304,8 +308,10 @@ function createClient(options) {
       serverPort: port,
       nextState: 2
     },function(err){
-      if(err)
-        throw err;
+      if(err) {
+        client.emit('error',err);
+        return;
+      }
       client.state = states.LOGIN;
       client.write(0x00, {
         username: client.username
@@ -371,8 +377,10 @@ function createClient(options) {
           sharedSecret: encryptedSharedSecretBuffer,
           verifyToken: encryptedVerifyTokenBuffer,
         },function(err){
-          if(err)
-            throw err;
+          if(err) {
+            client.emit('error',err);
+            return;
+          }
           client.encryptionEnabled = true;
         });
       }

--- a/src/ping.js
+++ b/src/ping.js
@@ -38,8 +38,10 @@ function ping(options, cb) {
       serverPort: port,
       nextState: 1
     },function(err){
-      if(err)
-        throw err;
+      if(err) {
+        client.emit('error',err);
+        return;
+      }
       client.state = states.STATUS;
     });
   });


### PR DESCRIPTION
That's probably better.
That means no crash and we let the user of nmp know about errors by listening to "error" if needed. And the user of client.write can act on errors based on the result of the callback.

After this commit only 4 throws are left : 
* one in writeRaw that would disappear if we do the same as for write : add a callback
* 3 in protocol.js that could be removed if we make the errors go into callbacks or returns