### PR TITLE
Keep alive option

### DIFF
--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -77,7 +77,8 @@ if(host.indexOf(':') != -1) {
 
 var srv = mc.createServer({
   'online-mode': false,
-  port: 25566
+  port: 25566,
+  keepAlive: false
 });
 srv.on('login', function(client) {
   var addr = client.socket.remoteAddress;
@@ -101,7 +102,8 @@ srv.on('login', function(client) {
     port: port,
     username: user,
     password: passwd,
-    'online-mode': passwd != null ? true : false
+    'online-mode': passwd != null ? true : false,
+    keepAlive:false
   });
   var brokenPackets = [/*0x04, 0x2f, 0x30*/];
   client.on('packet', function(packet) {

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -26,6 +26,8 @@ function createServer(options) {
   // and returning a modified response object.
   var beforePing = options.beforePing || null;
 
+  var enableKeepAlive = options.keepAlive == null ? true : options.keepAlive;
+
   var serverKey = ursa.generatePrivateKey(1024);
 
   var server = new Server(options);
@@ -194,7 +196,7 @@ function createServer(options) {
       client.write(0x02, {uuid: client.uuid, username: client.username});
       client.state = states.PLAY;
       loggedIn = true;
-      startKeepAlive();
+      if(enableKeepAlive) startKeepAlive();
 
       clearTimeout(loginKickTimer);
       loginKickTimer = null;


### PR DESCRIPTION
Useful to fix proxy.js disconnection when there is some lag (when the proxy is not on localhost)
Might be related with #188 , @lastuniverse does it fix things for you ?

Related with #210 but also kind of independent imho : there's already a keepAlive option in createClient, one was missing from createServer

Edit: stupid test not-really-failing because of #194 