### PR TITLE
Print some more info in order to fix https://github.com/PrismarineJS/node-minecraft-protocol/issues/194

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "power-assert": "^1.0.0",
     "source-map-support": "^0.3.2",
     "zfill": "0.0.1",
-    "minecraft-wrap": "0.5.3"
+    "minecraft-wrap": "~0.5.4"
   },
   "dependencies": {
     "babel-runtime": "^5.4.4",

--- a/test/test.js
+++ b/test/test.js
@@ -222,6 +222,9 @@ describe("client", function() {
     });
   });
   it("pings the server", function(done) {
+    wrap.on('line',function(line){
+      console.log(line);
+    });
     wrap.startServer({
       motd: 'test1234',
       'max-players': 120,


### PR DESCRIPTION
Maybe we should let this on until we fix https://github.com/PrismarineJS/node-minecraft-protocol/issues/194

It prints more stuff into the circle ci build ( https://circleci.com/gh/rom1504/node-minecraft-protocol/148 )
so we can figure out what goes wrong when it fails