### PR TITLE
remove zfill dependency used nowhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "mocha": "~1.8.2",
     "power-assert": "^1.0.0",
     "source-map-support": "^0.3.2",
-    "zfill": "0.0.1",
     "minecraft-wrap": "~0.5.4"
   },
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,6 @@ var mc = require('../')
   , fs = require('fs')
   , net = require('net')
   , assert = require('power-assert')
-  , zfill = require('zfill')
   , MC_SERVER_JAR = process.env.MC_SERVER_JAR
   , SURVIVE_TIME = 10000
   , MC_SERVER_PATH = path.join(__dirname, 'server')


### PR DESCRIPTION
It used to be there https://github.com/PrismarineJS/node-minecraft-protocol/blob/c46767088064b384da36c1213a13f14e3038cb40/test/test.js#L143

Maybe we should use something like this somewhere else in the code, like https://github.com/PrismarineJS/node-minecraft-protocol/blob/3bbb1eae6a9d34b007ebf8ca34240512e24d814a/src/transforms/serializer.js#L128 ?

So anyway, use zfill or remove it.