### PR TITLE
Allow beforePing to receive a callback.

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -100,15 +100,25 @@ function createServer(options) {
         "favicon": server.favicon
       };
 
+      function answerToPing(err, response) {
+        if ( err ) return;
+        client.write('server_info', {response: JSON.stringify(response)});
+      }
+
       if(beforePing) {
-        response = beforePing(response, client) || response;
+        if ( beforePing.length > 2 ) {
+          beforePing(response, client, answerToPing);
+        } else {
+          answerToPing(null, beforePing(response, client) || response);
+        }
+      } else {
+        answerToPing(null, response);
       }
 
       client.once('ping', function(packet) {
         client.write('ping', {time: packet.time});
         client.end();
       });
-      client.write('server_info', {response: JSON.stringify(response)});
     }
 
     function onLogin(packet) {


### PR DESCRIPTION
Sometimes a server needs to preform some asnyc operation before it can respond to a ping request.  To handle this case, we allow the return value of before ping to be a thenable, and then wait on that promise.

By returning a thenable instead of sending callback, we easily maintain backwards compatibility. 