### PR TITLE
Allow clients to specify session information and skip talking to Yggdrasil

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -64,7 +64,14 @@ function createClient(options) {
       }
     };
 
-    if(accessToken != null) getSession(options.username, accessToken, clientToken, true, cb);
+    if(options.selectedProfile) {
+      cb(null,{
+        accessToken: accessToken,
+        clientToken: clientToken,
+        username: options.selectedProfile.name,
+        selectedProfile: options.selectedProfile
+      });
+    } else if(accessToken != null) getSession(options.username, accessToken, clientToken, true, cb);
     else getSession(options.username, options.password, clientToken, false, cb);
   } else {
     // assume the server is in offline mode and just go for it.


### PR DESCRIPTION
If we already have the selectedProfile in hand, we don't need to talk to Yggdrasil.  When creating a client now, we always refresh the auth token to get the selected profile, causing the access token to be rotated. Passing the session information allows the user to stop the token from being rotated, so it can continue to be used.