### PR TITLE
use mocha for benchmark (allow better mocha grepping + it's cleaner)

### DIFF
--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,8 +1,8 @@
 var ITERATIONS = 100000;
 
 var mc = require("../");
-  util = require('util'),
-  states = mc.states;
+var util = require('util');
+var states = mc.states;
 
 var testDataWrite = [
   {name: 'keep_alive', params: {keepAliveId: 957759560}},
@@ -12,23 +12,34 @@ var testDataWrite = [
 ];
 
 mc.supportedVersions.forEach(function(supportedVersion){
-  var inputData = [];
-  var serializer=new mc.createSerializer({state:states.PLAY,isServer:false,version:supportedVersion});
-  var start, i, j;
-  console.log('Beginning write test for '+supportedVersion);
-  start = Date.now();
-  for(i = 0; i < ITERATIONS; i++) {
-    for(j = 0; j < testDataWrite.length; j++) {
-      inputData.push(serializer.createPacketBuffer(testDataWrite[j].name, testDataWrite[j].params));
-    }
-  }
-  console.log('Finished write test in ' + (Date.now() - start) / 1000 + ' seconds');
+  var mcData=require("minecraft-data")(supportedVersion);
+  var version=mcData.version;
+  describe("benchmark "+version.minecraftVersion,function(){
+    var inputData = [];
+    it("bench serializing",function(done){
+      var serializer=new mc.createSerializer({state:states.PLAY,isServer:false,version:version.majorVersion});
+      var start, i, j;
+      console.log('Beginning write test');
+      start = Date.now();
+      for(i = 0; i < ITERATIONS; i++) {
+        for(j = 0; j < testDataWrite.length; j++) {
+          inputData.push(serializer.createPacketBuffer(testDataWrite[j].name, testDataWrite[j].params));
+        }
+      }
+      var result=(Date.now() - start) / 1000;
+      console.log('Finished write test in ' + result + ' seconds');
+      done();
+    });
 
-  var deserializer=new mc.createDeserializer({state:states.PLAY,isServer:true,version:supportedVersion});
-  console.log('Beginning read test for '+supportedVersion);
-  start = Date.now();
-  for (j = 0; j < inputData.length; j++) {
-    deserializer.parsePacketData(inputData[j]);
-  }
-  console.log('Finished read test in ' + (Date.now() - start) / 1000 + ' seconds');
+    it("bench parsing",function(done){
+      var deserializer=new mc.createDeserializer({state:states.PLAY,isServer:true,version:version.majorVersion});
+      console.log('Beginning read test');
+      start = Date.now();
+      for (j = 0; j < inputData.length; j++) {
+        deserializer.parsePacketData(inputData[j]);
+      }
+      console.log('Finished read test in ' + (Date.now() - start) / 1000 + ' seconds');
+      done();
+    });
+  });
 });

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -15,6 +15,7 @@ mc.supportedVersions.forEach(function(supportedVersion){
   var mcData=require("minecraft-data")(supportedVersion);
   var version=mcData.version;
   describe("benchmark "+version.minecraftVersion,function(){
+    this.timeout(20 * 1000);
     var inputData = [];
     it("bench serializing",function(done){
       var serializer=new mc.createSerializer({state:states.PLAY,isServer:false,version:version.majorVersion});


### PR DESCRIPTION
These tests always succeed. It would be possible to check they don't take too much time, but what value should we compare against ?
* a fixed value : would fail for slower computer
* something specific to circle ci : producing circle ci artifact containing the last score value + comparing against the score value of the parent commit : this seems a bit overkill though

Anyway, I think this can be merged as-is, we can figure out how to make these tests fail later.

Edit: Well mocha has a build-in timeout so I set it to 20s for now, to be safe.