### PR TITLE
remove unnecessary proxy dependency (it's already in nmp package.json)

### DIFF
--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "buffer-equal": "0.0.1"
   },
   "description": "A node-minecraft-protocol example"
 }

--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -1,4 +1,5 @@
 var mc = require('../../');
+var bufferEqual = require('buffer-equal');
 
 var states = mc.states;
 function printHelpAndExit(exitCode) {
@@ -128,7 +129,6 @@ srv.on('login', function(client) {
         client.compressionThreshold = data.threshold;
     }
   });
-  var bufferEqual = require('buffer-equal');
   targetClient.on('raw', function(buffer, meta) {
     if(client.state != states.PLAY || meta.state != states.PLAY)
       return;


### PR DESCRIPTION
We might want to consider not having the dir for every example but client_chat