### PR TITLE
use require-self to be able to use require('minecraft-protocol') in examples

### DIFF
--- a/examples/client_chat/client_chat.js
+++ b/examples/client_chat/client_chat.js
@@ -1,6 +1,6 @@
 var readline = require('readline');
 var color = require("ansi-color").set;
-var mc = require('../../');
+var mc = require('minecraft-protocol');
 var states = mc.states;
 var util = require('util');
 

--- a/examples/client_echo/client_echo.js
+++ b/examples/client_echo/client_echo.js
@@ -1,4 +1,4 @@
-var mc = require('../../');
+var mc = require('minecraft-protocol');
 
 if(process.argv.length < 4 || process.argv.length > 6) {
   console.log("Usage : node echo.js <host> <port> [<name>] [<password>]");

--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -1,4 +1,4 @@
-var mc = require('../../');
+var mc = require('minecraft-protocol');
 
 var states = mc.states;
 function printHelpAndExit(exitCode) {

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -1,4 +1,4 @@
-var mc = require('../../');
+var mc = require('minecraft-protocol');
 var states = mc.states;
 
 var options = {

--- a/examples/server_helloworld/server_helloworld.js
+++ b/examples/server_helloworld/server_helloworld.js
@@ -1,4 +1,4 @@
-var mc = require('../../');
+var mc = require('minecraft-protocol');
 
 var options = {
   'online-mode': true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/PrismarineJS/node-minecraft-protocol.git"
   },
   "scripts": {
-    "prepublish": "gulp",
+    "prepublish": "gulp && require-self",
     "test": "mocha --recursive --require intelli-espower-loader --require source-map-support/register --reporter spec"
   },
   "keywords": [
@@ -29,16 +29,17 @@
   "browser": "browser.js",
   "devDependencies": {
     "chai": "^2.3.0",
+    "espower-loader": "^1.0.0",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",
     "gulp-plumber": "^1.0.1",
     "gulp-sourcemaps": "^1.3.0",
-    "espower-loader":"^1.0.0",
     "intelli-espower-loader": "^1.0.0",
+    "minecraft-wrap": "~0.6.5",
     "mocha": "~2.3.3",
     "power-assert": "^1.0.0",
-    "source-map-support": "^0.3.2",
-    "minecraft-wrap": "~0.6.5"
+    "require-self": "^0.1.0",
+    "source-map-support": "^0.3.2"
   },
   "dependencies": {
     "babel-runtime": "^5.4.4",


### PR DESCRIPTION
Seems nicer to me !

Less confusing for users. (and yes, it works)