### PR TITLE
Update browser.js, sync with index.js excluding createClient/createServer

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,12 @@
+var Client = require('./client');
+var Server = require('./server');
+var serializer = require("./transforms/serializer");
+
 module.exports = {
-  Client: require('./client'),
+  Client: Client,
+  Server: Server,
+  states: require("./states"),
+  createSerializer:serializer.createSerializer,
+  createDeserializer:serializer.createDeserializer,
   supportedVersions:require("./version").supportedVersions
 };


### PR DESCRIPTION
All of node-minecraft-protocol can be browserified, except for createClient and createServer (since it depends on request, and browsers cannot send arbitrary HTTP requests to third-party servers (yggdrasil, authentication)).

Primarily I'd like access to `states` (instead of using `require('minecraft-data')(mcversion).protocol.states`; see https://github.com/deathcap/wsmc/commit/2fbfd59e4c951580ec98ae4b6dce62b8769e0a24#comments), but I added all the other fields too since they browserify without error.