### PR TITLE
Test on newer version of Node

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     MC_SERVER_JAR_DIR: /home/ubuntu/node-minecraft-protocol/minecraft-server/
   node:
-    version: 0.10.28
+    version: 4
   java:
     version: openjdk7
 dependencies:


### PR DESCRIPTION
circle.yml specified a very old version of node (0.10.28), current versions on https://nodejs.org/en/ are v4 (LTS) and v5 (stable).

CircleCI documentation on their installed node versions: https://circleci.com/docs/environment#node-js

How to test multiple node versions on CircleCI: https://discuss.circleci.com/t/testing-multiple-versions-of-node/542 (this is simpler on Travis CI you just list all the versions in an array; requires test overrides on Circle – punting on making this change for this PR for now)