### PR TITLE
Send framed packets in one push()

### DIFF
--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -15,10 +15,10 @@ class Framer extends Transform {
   }
 
   _transform(chunk, enc, cb) {
-    var buffer = new Buffer(sizeOfVarInt(chunk.length));
+    var buffer = new Buffer(sizeOfVarInt(chunk.length) + chunk.length);
     writeVarInt(chunk.length, buffer, 0);
+    chunk.copy(buffer, sizeOfVarInt(chunk.length));
     this.push(buffer);
-    this.push(chunk);
     return cb();
   }
 }


### PR DESCRIPTION
Before the streams refactor, MC packets were sent with the packet length prefix and payload combined in one call. This PR restores this behavior, instead of sending the packet length and payload in two separate `this.push()` calls.

ref: https://github.com/deathcap/wsmc/pull/21#issuecomment-172284334

(With this change, browserified mineflayer now works with the latest node-minecraft-protocol)