### PR TITLE
Remove unused chai dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "browser": "browser.js",
   "devDependencies": {
-    "chai": "^2.3.0",
     "espower-loader": "^1.0.0",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",


### PR DESCRIPTION
chai was added in https://github.com/PrismarineJS/node-minecraft-protocol/commit/dd2cfa1fa382498a78a24ac23c596e149af83689 for test/dataTypes/numeric.js, but those tests were moved to protodef in https://github.com/PrismarineJS/node-minecraft-protocol/commit/f45c6dff49cbc12903ac2c1b9d408e23d029c290 so chai is no longer needed in node-minecraft-protocol