### PR TITLE
Show disconnect reason in examples

### DIFF
--- a/examples/client_chat/client_chat.js
+++ b/examples/client_chat/client_chat.js
@@ -93,6 +93,10 @@ client.on('connect', function() {
   console.info(color('Successfully connected to ' + host + ':' + port, "blink+green"));
 });
 
+client.on('disconnect', function(packet) {
+  console.log('disconnected: '+ packet.reason);
+});
+
 client.on('end', function() {
   console.log("Connection lost");
   process.exit();

--- a/examples/client_echo/client_echo.js
+++ b/examples/client_echo/client_echo.js
@@ -15,6 +15,9 @@ var client = mc.createClient({
 client.on('connect', function() {
   console.info('connected');
 });
+client.on('disconnect', function(packet) {
+  console.log('disconnected: '+ packet.reason);
+});
 client.on('chat', function(packet) {
   var jsonMsg = JSON.parse(packet.message);
   if(jsonMsg.translate == 'chat.type.announcement' || jsonMsg.translate == 'chat.type.text') {


### PR DESCRIPTION
When the examples clients are disconnected, they currently silently exit. This PR adds the disconnect reason, with informative text explaining why the disconnection occurred, such as:

```
node-minecraft-protocol $ node examples/client_echo/client_echo.js localhost 25565
connected
disconnected: "This server requires FML/Forge to be installed. Contact your server admin for more details."
```

(note: there are quotes around the reason because the reason field in this packet http://wiki.vg/Protocol#Disconnect_2 is not a string but a 'chat' type, but I think it's good enough for an example)