### PR TITLE
Add debug logging for received packet data

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -75,6 +75,8 @@ class Client extends EventEmitter
       parsed.metadata.name=parsed.data.name;
       parsed.data=parsed.data.params;
       parsed.metadata.state=state;
+      debug("read packet " + state + "." + parsed.metadata.name);
+      debug(parsed.data);
       this.emit('packet', parsed.data, parsed.metadata);
       this.emit(parsed.metadata.name, parsed.data, parsed.metadata);
       this.emit('raw.' + parsed.metadata.name, parsed.buffer, parsed.metadata);


### PR DESCRIPTION
`NODE_DEBUG=mc-proto` would log packets written, but not read, making debugging difficult. This PR adds debug logging to received packet data as well. Example usage:

node-minecraft-protocol $ NODE_DEBUG=mc-proto node examples/client_echo/client_echo.js localhost 25565
MC-PROTO: 16784 writing packet handshaking.set_protocol
MC-PROTO: 16784 { protocolVersion: 47,
  serverHost: 'localhost',
  serverPort: 25565,
  nextState: 2 }
MC-PROTO: 16784 writing packet login.login_start
MC-PROTO: 16784 { username: 'echo' }
connected
MC-PROTO: 16784 read packet login.disconnect
MC-PROTO: 16784 { reason: '"This server requires FML/Forge to be installed. Contact your server admin for more details."' }
disconnected: "This server requires FML/Forge to be installed. Contact your server admin for more details."
