### PR TITLE
[WIP] Add plugin channel API to NMP

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -95,6 +95,13 @@ False if it is a connection from client to server.
 
 Returns the internal nodejs Socket used to communicate with this client.
 
+### client.outgoingPluginChannels.write(channel, data)
+### client.outgoingPluginChannels.register(channels...)
+### client.outgoingPluginChannels.unregister(channels...)
+
+Writes a raw payload buffer to an outgoing plugin channel. Registering and unregistering
+channels notifies the other side.
+
 ### client.uuid
 
 A string representation of the client's UUID. Note that UUIDs are unique for
@@ -134,6 +141,11 @@ parameters.
 ### per-packet events
 
 Check out the [minecraft-data docs](https://prismarinejs.github.io/minecraft-data/?v=1.8&d=protocol) to know the event names and data field names.
+
+### per-channel events
+
+`client.incomingPluginChannels` emits events for each plugin channel.
+The raw payload buffer is passed as the first argument.
 
 ## Not Immediately Obvious Data Type Formats
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -96,8 +96,6 @@ False if it is a connection from client to server.
 Returns the internal nodejs Socket used to communicate with this client.
 
 ### client.outgoingPluginChannels.write(channel, data)
-### client.outgoingPluginChannels.register(channels...)
-### client.outgoingPluginChannels.unregister(channels...)
 
 Writes a raw payload buffer to an outgoing plugin channel. Registering and unregistering
 channels notifies the other side.

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -25,9 +25,6 @@ function createClient(options) {
 
   var client = new Client(false, options.majorVersion);
 
-  client.incomingPluginChannels = new IncomingPluginChannels(client);
-  client.outgoingPluginChannels = new OutgoingPluginChannels(client);
-
   tcp_dns(client, options);
   setProtocol(client, options);
   keepalive(client, options);

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -9,6 +9,8 @@ var yggserver = require('yggdrasil').server({});
 var states = require("./states");
 var debug = require("./debug");
 var UUID = require('uuid-1345');
+var IncomingPluginChannels = require('./pluginChannels').IncomingPluginChannels;
+var OutgoingPluginChannels = require('./pluginChannels').OutgoingPluginChannels;
 
 module.exports=createClient;
 
@@ -45,6 +47,8 @@ function createClient(options) {
 
 
   var client = new Client(false,version.majorVersion);
+  client.incomingPluginChannels = new IncomingPluginChannels(client);
+  client.outgoingPluginChannels = new OutgoingPluginChannels(client);
   client.on('connect', onConnect);
   if(keepAlive) client.on('keep_alive', onKeepAlive);
   client.once('encryption_begin', onEncryptionKeyRequest);

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -1,0 +1,69 @@
+var EventEmitter = require('events').EventEmitter;
+
+function serializeChannelList(channels) {
+  return new Buffer(channels.join('\0'));
+}
+
+function parseChannelList(buffer) {
+  return buffer.toString().split('\0');
+}
+
+class PluginChannels extends EventEmitter {
+  constructor(client) {
+    super();
+    this.client = client;
+    this.channels = [];
+  }
+}
+
+class IncomingPluginChannels extends PluginChannels {
+  constructor(client) {
+    super(client);
+
+    client.on('custom_payload', (packet) => {
+      client.incomingPluginChannels.emit(packet.channel, packet.data);
+
+      if (packet.channel === 'REGISTER') {
+        parseChannelList(packet.data).forEach((channel) => {
+          this.channels.push(channel);
+        });
+      } else if (packet.channel === 'UNREGISTER') {
+        parseChannelList(packet.data).forEach((channel) => {
+          this.channels.pop(channel);
+        });
+      }
+    });
+  }
+}
+
+class OutgoingPluginChannels extends PluginChannels {
+  constructor(client) {
+    super(client);
+  }
+
+  write(channel, data) {
+    this.client.write('custom_payload', {
+      channel: channel,
+      data: data
+    });
+  }
+
+  register(...channels) {
+    this.write('REGISTER', serializeChannelList(channels));
+    this.channels.forEach((channel) => {
+      this.channels.push(channel);
+    });
+  }
+
+  unregister(...channels) {
+    this.write('UNREGISTER', serializeChannelList(channels));
+    this.channels.forEach((channel) => {
+      this.channels.pop(channel);
+    });
+  }
+}
+
+module.exports = {
+  IncomingPluginChannels,
+  OutgoingPluginChannels
+};

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -4,7 +4,6 @@ class PluginChannels extends EventEmitter {
   constructor(client) {
     super();
     this.client = client;
-    this.channels = new Set();
   }
 }
 
@@ -31,7 +30,7 @@ class OutgoingPluginChannels extends PluginChannels {
   }
 }
 
-module.exports = {
-  IncomingPluginChannels,
-  OutgoingPluginChannels
+module.exports = function(client, options) {
+  client.incomingPluginChannels = new IncomingPluginChannels(client);
+  client.outgoingPluginChannels = new OutgoingPluginChannels(client);
 };

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -1,13 +1,5 @@
 var EventEmitter = require('events').EventEmitter;
 
-function serializeChannelList(channels) {
-  return new Buffer(channels.join('\0'));
-}
-
-function parseChannelList(buffer) {
-  return buffer.toString().split('\0');
-}
-
 class PluginChannels extends EventEmitter {
   constructor(client) {
     super();
@@ -22,16 +14,6 @@ class IncomingPluginChannels extends PluginChannels {
 
     client.on('custom_payload', (packet) => {
       client.incomingPluginChannels.emit(packet.channel, packet.data);
-
-      if (packet.channel === 'REGISTER') {
-        parseChannelList(packet.data).forEach((channel) => {
-          this.channels.add(channel);
-        });
-      } else if (packet.channel === 'UNREGISTER') {
-        parseChannelList(packet.data).forEach((channel) => {
-          this.channels.delete(channel);
-        });
-      }
     });
   }
 }
@@ -45,20 +27,6 @@ class OutgoingPluginChannels extends PluginChannels {
     this.client.write('custom_payload', {
       channel: channel,
       data: data
-    });
-  }
-
-  register(...channels) {
-    this.write('REGISTER', serializeChannelList(channels));
-    this.channels.forEach((channel) => {
-      this.channels.add(channel);
-    });
-  }
-
-  unregister(...channels) {
-    this.write('UNREGISTER', serializeChannelList(channels));
-    this.channels.forEach((channel) => {
-      this.channels.delete(channel);
     });
   }
 }

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -31,7 +31,7 @@ module.exports = function(client, options) {
       }
       // If we want more, wait until we get more
       if (!areWeDone)
-        client.on('custom_payload', function bleh(data) {
+        client.on('custom_payload', (data) => {
            // When push returns false, we should stop reading until _read is called again.
           if (!this.push(this.readStuff.unshift()))
             client.removeEventListener('custom_payload', bleh);

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -1,36 +1,39 @@
-var EventEmitter = require('events').EventEmitter;
-
-class PluginChannels extends EventEmitter {
-  constructor(client) {
-    super();
-    this.client = client;
-  }
-}
-
-class IncomingPluginChannels extends PluginChannels {
-  constructor(client) {
-    super(client);
-
-    client.on('custom_payload', (packet) => {
-      client.incomingPluginChannels.emit(packet.channel, packet.data);
-    });
-  }
-}
-
-class OutgoingPluginChannels extends PluginChannels {
-  constructor(client) {
-    super(client);
-  }
-
-  write(channel, data) {
-    this.client.write('custom_payload', {
-      channel: channel,
-      data: data
-    });
-  }
-}
+var Duplex = require('readable-stream').Duplex;
 
 module.exports = function(client, options) {
-  client.incomingPluginChannels = new IncomingPluginChannels(client);
-  client.outgoingPluginChannels = new OutgoingPluginChannels(client);
+  let channelCache = new Set();
+
+  class PluginChannelStream extends Duplex {
+    constructor(name) {
+      super();
+      this.name = name;
+    }
+
+    _write(chunk, encoding, cb) {
+      client.write('custom_payload', {
+        channel: name,
+        data: data
+      });
+      cb(null); // sync
+    }
+
+    _read() {
+      //TODO
+      /*
+      client.on('custom_payload', (packet) => {
+      client.incomingPluginChannels.emit(packet.channel, packet.data);
+      */
+    }
+  }
+
+
+  client.pluginChannel = (name) => {
+    if (channelCache[name]) {
+      return channelCache[name];
+    }
+
+    let channel = new PluginChannelStream();
+    channelCache[name] = channel;
+    return channel;
+  };
 };

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -12,7 +12,7 @@ class PluginChannels extends EventEmitter {
   constructor(client) {
     super();
     this.client = client;
-    this.channels = [];
+    this.channels = new Set();
   }
 }
 
@@ -25,11 +25,11 @@ class IncomingPluginChannels extends PluginChannels {
 
       if (packet.channel === 'REGISTER') {
         parseChannelList(packet.data).forEach((channel) => {
-          this.channels.push(channel);
+          this.channels.add(channel);
         });
       } else if (packet.channel === 'UNREGISTER') {
         parseChannelList(packet.data).forEach((channel) => {
-          this.channels.pop(channel);
+          this.channels.delete(channel);
         });
       }
     });
@@ -51,14 +51,14 @@ class OutgoingPluginChannels extends PluginChannels {
   register(...channels) {
     this.write('REGISTER', serializeChannelList(channels));
     this.channels.forEach((channel) => {
-      this.channels.push(channel);
+      this.channels.add(channel);
     });
   }
 
   unregister(...channels) {
     this.write('UNREGISTER', serializeChannelList(channels));
     this.channels.forEach((channel) => {
-      this.channels.pop(channel);
+      this.channels.delete(channel);
     });
   }
 }


### PR DESCRIPTION
Adds the start of an API for "plugin channels" in node-minecraft-protocol

Use cases include:

* https://github.com/PrismarineJS/node-minecraft-protocol/issues/152 Handle official (MC| - prefixed) Custom Payload packets
* https://github.com/PrismarineJS/node-minecraft-protocol/issues/114 Forge Support
 * https://github.com/PrismarineJS/node-minecraft-protocol/pull/326 Forge client support - experimenting building on this API for `FML|HS` in internal PR: https://github.com/deathcap/node-minecraft-protocol/pull/2
* https://github.com/PrismarineJS/mineflayer/issues/361 Plugin channel API in mineflayer
 * [MC|AdvCdm](https://github.com/PrismarineJS/mineflayer/commit/24f24349261c5b5031ff4ec624fef670af3028a5), [MC|Brand](https://github.com/PrismarineJS/mineflayer/issues/253)

To do:

* [ ] Rework to use nodejs streams