### PR TITLE
[WIP] Intra-release multi-protocol support

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ automatically logged in and validated against mojang's auth.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : 1.8 or 1.9 : default to 1.8
+ * protocolVersion : optional protocol version number, if omitted inferred from `version`
 
 ## mc.Server(version)
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -42,6 +42,7 @@ function createClient(options) {
   var optVersion = options.version || require("./version").defaultVersion;
   var mcData=require("minecraft-data")(optVersion);
   var version = mcData.version;
+  var protocolVersion = options.protocolVersion || version.version;
 
 
   var client = new Client(false,version.majorVersion);
@@ -91,7 +92,7 @@ function createClient(options) {
 
   function onConnect() {
     client.write('set_protocol', {
-      protocolVersion: version.version,
+      protocolVersion: protocolVersion,
       serverHost: host,
       serverPort: port,
       nextState: 2


### PR DESCRIPTION
`createClient()` accepts a "version" option to specify a Minecraft release, which is used to lookup the dataset in [minecraft-data](https://github.com/PrismarineJS/minecraft-data) via [node-minecraft-data](https://github.com/PrismarineJS/node-minecraft-data) (translating it to a major version, but see https://github.com/PrismarineJS/node-minecraft-data/issues/13, e.g. 1.8.9 -> 1.8), in turn used to set the protocol version in the `set_protocol` packet handshake, limiting the multi-protocol support of NMP to one protocol per major release.

This PR adds another option `protocolVersion`, clients can use to specify the exact protocol version to use. Data will still be used from minecraft-data based on `version`, but since `version`/minecraft-data specifies a major release, this additional `protocolVersion` option will allow clients to use minor "sub-versions" within the major version.

---

(Note: the client app is on their own when it comes to handling minor version discrepancies. 15w40b/76 for example is not compatible with 16w03a/96 because they renumbered all the packets. minecraft-data will probably just support one snapshot version at a time, the latest since it was updated. But `protocolVersion` would still be useful for smaller protocol updates where packets are added/removed but mostly compatible otherwise.)