### PR TITLE
Modularization attempt of createClient()

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -215,6 +215,13 @@ class Client extends EventEmitter
     else
       this.compressor.write(buffer);
   }
+
+  // TCP/IP-specific (not generic Stream) method for backwards-compatibility
+  connect(port, host) {
+    var options = {port, host};
+    require('./client/tcp_dns')(this, options);
+    options.connect(this);
+  }
 }
 
 module.exports = Client;

--- a/src/client/caseCorrect.js
+++ b/src/client/caseCorrect.js
@@ -16,7 +16,7 @@ module.exports = function(client, options) {
         client.username = session.selectedProfile.name;
         accessToken = session.accessToken;
         client.emit('session');
-        client.connect(options.port, options.host);
+        options.connect(client);
       }
     };
 
@@ -38,6 +38,6 @@ module.exports = function(client, options) {
   } else {
     // assume the server is in offline mode and just go for it.
     client.username = options.username;
-    client.connect(options.port, options.host);
+    options.connect(client);
   }
 };

--- a/src/client/caseCorrect.js
+++ b/src/client/caseCorrect.js
@@ -3,10 +3,10 @@ var UUID = require('uuid-1345');
 
 module.exports = function(client, options) {
   var clientToken = options.clientToken || UUID.v4().toString();
-  var accessToken;
-  var haveCredentials = options.password != null || (clientToken != null && options.session != null);
+  options.accessToken = null;
+  options.haveCredentials = options.password != null || (clientToken != null && options.session != null);
 
-  if(haveCredentials) {
+  if(options.haveCredentials) {
     // make a request to get the case-correct username before connecting.
     var cb = function(err, session) {
       if(err) {
@@ -14,7 +14,7 @@ module.exports = function(client, options) {
       } else {
         client.session = session;
         client.username = session.selectedProfile.name;
-        accessToken = session.accessToken;
+        options.accessToken = session.accessToken;
         client.emit('session');
         options.connect(client);
       }

--- a/src/client/caseCorrect.js
+++ b/src/client/caseCorrect.js
@@ -1,0 +1,43 @@
+var yggdrasil = require('yggdrasil')({});
+var UUID = require('uuid-1345');
+
+module.exports = function(client, options) {
+  var clientToken = options.clientToken || UUID.v4().toString();
+  var accessToken;
+  var haveCredentials = options.password != null || (clientToken != null && options.session != null);
+
+  if(haveCredentials) {
+    // make a request to get the case-correct username before connecting.
+    var cb = function(err, session) {
+      if(err) {
+        client.emit('error', err);
+      } else {
+        client.session = session;
+        client.username = session.selectedProfile.name;
+        accessToken = session.accessToken;
+        client.emit('session');
+        client.connect(options.port, options.host);
+      }
+    };
+
+    if (options.session) {
+      yggdrasil.validate(options.session.accessToken, function(ok) {
+        if (ok)
+          cb(null, options.session);
+        else
+          yggdrasil.refresh(options.session.accessToken, options.session.clientToken, function(err, _, data) {
+            cb(err, data);
+          });
+      });
+    }
+    else yggdrasil.auth({
+      user: options.username,
+      pass: options.password,
+      token: clientToken
+    }, cb);
+  } else {
+    // assume the server is in offline mode and just go for it.
+    client.username = options.username;
+    client.connect(options.port, options.host);
+  }
+};

--- a/src/client/compress.js
+++ b/src/client/compress.js
@@ -1,4 +1,4 @@
-module.exports = function(client) {
+module.exports = function(client, options) {
   client.once("compress", onCompressionRequest);
   client.on("set_compression", onCompressionRequest);
 

--- a/src/client/compress.js
+++ b/src/client/compress.js
@@ -1,0 +1,9 @@
+module.exports = function(client) {
+  client.once("compress", onCompressionRequest);
+  client.on("set_compression", onCompressionRequest);
+
+  function onCompressionRequest(packet) {
+    client.compressionThreshold = packet.threshold;
+  }
+  // TODO: refactor with transforms/compression.js -- enable it here
+};

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -3,7 +3,7 @@ var yggserver = require('yggdrasil').server({});
 var ursa=require("../ursa");
 var debug = require("../debug");
 
-module.exports = function(client) {
+module.exports = function(client, options) {
   client.once('encryption_begin', onEncryptionKeyRequest);
 
   function onEncryptionKeyRequest(packet) {

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -1,0 +1,65 @@
+var crypto = require('crypto');
+var yggserver = require('yggdrasil').server({});
+var debug = require("../debug");
+
+module.exports = function(client) {
+  client.once('encryption_begin', onEncryptionKeyRequest);
+
+  function onEncryptionKeyRequest(packet) {
+    crypto.randomBytes(16, gotSharedSecret);
+
+    function gotSharedSecret(err, sharedSecret) {
+      if(err) {
+        debug(err);
+        client.emit('error', err);
+        client.end();
+        return;
+      }
+      if(haveCredentials) {
+        joinServerRequest(onJoinServerResponse);
+      } else {
+        if(packet.serverId != '-') {
+          debug('This server appears to be an online server and you are providing no password, the authentication will probably fail');
+        }
+        sendEncryptionKeyResponse();
+      }
+
+      function onJoinServerResponse(err) {
+        if(err) {
+          client.emit('error', err);
+          client.end();
+        } else {
+          sendEncryptionKeyResponse();
+        }
+      }
+
+      function joinServerRequest(cb) {
+        yggserver.join(accessToken, client.session.selectedProfile.id,
+            packet.serverId, sharedSecret, packet.publicKey, cb);
+      }
+
+      function sendEncryptionKeyResponse() {
+        var pubKey = mcPubKeyToURsa(packet.publicKey);
+        var encryptedSharedSecretBuffer = pubKey.encrypt(sharedSecret, undefined, undefined, ursa.RSA_PKCS1_PADDING);
+        var encryptedVerifyTokenBuffer = pubKey.encrypt(packet.verifyToken, undefined, undefined, ursa.RSA_PKCS1_PADDING);
+        client.write('encryption_begin', {
+          sharedSecret: encryptedSharedSecretBuffer,
+          verifyToken: encryptedVerifyTokenBuffer
+        });
+        client.setEncryption(sharedSecret);
+      }
+    }
+  }
+};
+
+function mcPubKeyToURsa(mcPubKeyBuffer) {
+  var pem = "-----BEGIN PUBLIC KEY-----\n";
+  var base64PubKey = mcPubKeyBuffer.toString('base64');
+  var maxLineLength = 65;
+  while(base64PubKey.length > 0) {
+    pem += base64PubKey.substring(0, maxLineLength) + "\n";
+    base64PubKey = base64PubKey.substring(maxLineLength);
+  }
+  pem += "-----END PUBLIC KEY-----\n";
+  return ursa.createPublicKey(pem, 'utf8');
+}

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto');
 var yggserver = require('yggdrasil').server({});
+var ursa=require("../ursa");
 var debug = require("../debug");
 
 module.exports = function(client) {

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -16,7 +16,7 @@ module.exports = function(client, options) {
         client.end();
         return;
       }
-      if(haveCredentials) {
+      if(options.haveCredentials) {
         joinServerRequest(onJoinServerResponse);
       } else {
         if(packet.serverId != '-') {
@@ -35,7 +35,7 @@ module.exports = function(client, options) {
       }
 
       function joinServerRequest(cb) {
-        yggserver.join(accessToken, client.session.selectedProfile.id,
+        yggserver.join(options.accessToken, client.session.selectedProfile.id,
             packet.serverId, sharedSecret, packet.publicKey, cb);
       }
 

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -1,0 +1,15 @@
+module.exports = function(client) {
+  client.on('keep_alive', onKeepAlive);
+
+  var timeout = null;
+
+  function onKeepAlive(packet) {
+    if (timeout)
+      clearTimeout(timeout);
+    timeout = setTimeout(() => client.end(), checkTimeoutInterval);
+    client.write('keep_alive', {
+      keepAliveId: packet.keepAliveId
+    });
+  }
+
+};

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -1,4 +1,9 @@
-module.exports = function(client) {
+module.exports = function(client, options) {
+  var keepAlive = options.keepAlive == null ? true : options.keepAlive;
+  if (!keepAlive) return;
+
+  var checkTimeoutInterval = options.checkTimeoutInterval || 10 * 1000;
+
   client.on('keep_alive', onKeepAlive);
 
   var timeout = null;

--- a/src/client/play.js
+++ b/src/client/play.js
@@ -1,0 +1,11 @@
+var states = require("../states");
+
+module.exports = function(client, options) {
+  client.once('success', onLogin);
+
+  function onLogin(packet) {
+    client.state = states.PLAY;
+    client.uuid = packet.uuid;
+    client.username = packet.username;
+  }
+};

--- a/src/client/setProtocol.js
+++ b/src/client/setProtocol.js
@@ -1,0 +1,21 @@
+
+var states = require("../states");
+
+module.exports = function(client, options) {
+  client.on('connect', onConnect);
+
+  function onConnect() {
+    client.write('set_protocol', {
+      protocolVersion: options.protocolVersion,
+      serverHost: options.host,
+      serverPort: options.port,
+      nextState: 2
+    });
+    client.state = states.LOGIN;
+    client.write('login_start', {
+      username: client.username
+    });
+  }
+
+
+}

--- a/src/client/tcp_dns.js
+++ b/src/client/tcp_dns.js
@@ -6,7 +6,7 @@ module.exports = function(client, options) {
   options.host = options.host || 'localhost';
 
   options.connect = (client) => {
-    if(options.port == 25565 && net.isIP(host) === 0) {
+    if(options.port == 25565 && net.isIP(options.host) === 0) {
       dns.resolveSrv("_minecraft._tcp." + options.host, function(err, addresses) {
         if(addresses && addresses.length > 0) {
           client.setSocket(net.connect(addresses[0].port, addresses[0].name));

--- a/src/client/tcp_dns.js
+++ b/src/client/tcp_dns.js
@@ -1,0 +1,21 @@
+var net = require('net');
+var dns = require('dns');
+
+module.exports = function(client, options) {
+  options.port = options.port || 25565;
+  options.host = options.host || 'localhost';
+
+  options.connect = (client) => {
+    if(options.port == 25565 && net.isIP(host) === 0) {
+      dns.resolveSrv("_minecraft._tcp." + options.host, function(err, addresses) {
+        if(addresses && addresses.length > 0) {
+          client.setSocket(net.connect(addresses[0].port, addresses[0].name));
+        } else {
+          client.setSocket(net.connect(options.port, options.host));
+        }
+      });
+    } else {
+      client.setSocket(net.connect(options.port, options.host));
+    }
+  };
+};

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -12,25 +12,24 @@ var play = require('./client/play');
 
 module.exports=createClient;
 
-Client.prototype.connect = function(port, host) {
-  var self = this;
-  if(port == 25565 && net.isIP(host) === 0) {
-    dns.resolveSrv("_minecraft._tcp." + host, function(err, addresses) {
-      if(addresses && addresses.length > 0) {
-        self.setSocket(net.connect(addresses[0].port, addresses[0].name));
-      } else {
-        self.setSocket(net.connect(port, host));
-      }
-    });
-  } else {
-    self.setSocket(net.connect(port, host));
-  }
-};
-
 function createClient(options) {
   assert.ok(options, "options is required");
   options.port = options.port || 25565;
   options.host = options.host || 'localhost';
+
+  options.connect = (client) => {
+    if(options.port == 25565 && net.isIP(host) === 0) {
+      dns.resolveSrv("_minecraft._tcp." + options.host, function(err, addresses) {
+        if(addresses && addresses.length > 0) {
+          client.setSocket(net.connect(addresses[0].port, addresses[0].name));
+        } else {
+          client.setSocket(net.connect(options.port, options.host));
+        }
+      });
+    } else {
+      client.setSocket(net.connect(options.port, options.host));
+    }
+  };
 
   assert.ok(options.username, "username is required");
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -3,7 +3,6 @@ var net = require('net');
 var dns = require('dns');
 var Client = require('./client');
 var assert = require('assert');
-var states = require("./states");
 var debug = require("./debug");
 
 var encrypt = require('./client/encrypt');
@@ -11,6 +10,7 @@ var keepalive = require('./client/keepalive');
 var compress = require('./client/compress');
 var caseCorrect = require('./client/caseCorrect');
 var setProtocol = require('./client/setProtocol');
+var play = require('./client/play');
 
 module.exports=createClient;
 
@@ -42,20 +42,14 @@ function createClient(options) {
   options.majorVersion = version.majorVersion;
   options.protocolVersion = version.version;
 
-
   var client = new Client(false, options.majorVersion);
+
   setProtocol(client, options);
   keepalive(client, options);
   encrypt(client);
-  client.once('success', onLogin);
+  play(client);
   compress(client);
   caseCorrect(client, options);
 
   return client;
-
-  function onLogin(packet) {
-    client.state = states.PLAY;
-    client.uuid = packet.uuid;
-    client.username = packet.username;
-  }
 }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,9 +1,7 @@
-var ursa=require("./ursa");
 var net = require('net');
 var dns = require('dns');
 var Client = require('./client');
 var assert = require('assert');
-var debug = require("./debug");
 
 var encrypt = require('./client/encrypt');
 var keepalive = require('./client/keepalive');

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -37,8 +37,6 @@ function createClient(options) {
 
   assert.ok(options.username, "username is required");
   var haveCredentials = options.password != null || (clientToken != null && options.session != null);
-  var keepAlive = options.keepAlive == null ? true : options.keepAlive;
-  var checkTimeoutInterval = options.checkTimeoutInterval || 10 * 1000;
 
   var optVersion = options.version || require("./version").defaultVersion;
   var mcData=require("minecraft-data")(optVersion);
@@ -47,7 +45,7 @@ function createClient(options) {
 
   var client = new Client(false,version.majorVersion);
   client.on('connect', onConnect);
-  if(keepAlive) keepalive(client);
+  keepalive(client, options);
   encrypt(client);
   client.once('success', onLogin);
   compress(client);

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -3,13 +3,13 @@ var net = require('net');
 var dns = require('dns');
 var Client = require('./client');
 var assert = require('assert');
-var yggdrasil = require('yggdrasil')({});
 var states = require("./states");
 var debug = require("./debug");
-var UUID = require('uuid-1345');
+
 var encrypt = require('./client/encrypt');
 var keepalive = require('./client/keepalive');
 var compress = require('./client/compress');
+var caseCorrect = require('./client/caseCorrect');
 
 module.exports=createClient;
 
@@ -30,13 +30,10 @@ Client.prototype.connect = function(port, host) {
 
 function createClient(options) {
   assert.ok(options, "options is required");
-  var port = options.port || 25565;
-  var host = options.host || 'localhost';
-  var clientToken = options.clientToken || UUID.v4().toString();
-  var accessToken;
+  options.port = options.port || 25565;
+  options.host = options.host || 'localhost';
 
   assert.ok(options.username, "username is required");
-  var haveCredentials = options.password != null || (clientToken != null && options.session != null);
 
   var optVersion = options.version || require("./version").defaultVersion;
   var mcData=require("minecraft-data")(optVersion);
@@ -49,48 +46,15 @@ function createClient(options) {
   encrypt(client);
   client.once('success', onLogin);
   compress(client);
-  if(haveCredentials) {
-    // make a request to get the case-correct username before connecting.
-    var cb = function(err, session) {
-      if(err) {
-        client.emit('error', err);
-      } else {
-        client.session = session;
-        client.username = session.selectedProfile.name;
-        accessToken = session.accessToken;
-        client.emit('session');
-        client.connect(port, host);
-      }
-    };
-
-    if (options.session) {
-      yggdrasil.validate(options.session.accessToken, function(ok) {
-        if (ok)
-          cb(null, options.session);
-        else
-          yggdrasil.refresh(options.session.accessToken, options.session.clientToken, function(err, _, data) {
-            cb(err, data);
-          });
-      });
-    }
-    else yggdrasil.auth({
-      user: options.username,
-      pass: options.password,
-      token: clientToken
-    }, cb);
-  } else {
-    // assume the server is in offline mode and just go for it.
-    client.username = options.username;
-    client.connect(port, host);
-  }
+  caseCorrect(client, options);
 
   return client;
 
   function onConnect() {
     client.write('set_protocol', {
       protocolVersion: version.version,
-      serverHost: host,
-      serverPort: port,
+      serverHost: options.host,
+      serverPort: options.port,
       nextState: 2
     });
     client.state = states.LOGIN;

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -26,9 +26,9 @@ function createClient(options) {
   tcp_dns(client, options);
   setProtocol(client, options);
   keepalive(client, options);
-  encrypt(client);
-  play(client);
-  compress(client);
+  encrypt(client, options);
+  play(client, options);
+  compress(client, options);
   caseCorrect(client, options);
 
   return client;

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -9,6 +9,7 @@ var debug = require("./debug");
 var UUID = require('uuid-1345');
 var encrypt = require('./client/encrypt');
 var keepalive = require('./client/keepalive');
+var compress = require('./client/compress');
 
 module.exports=createClient;
 
@@ -49,8 +50,7 @@ function createClient(options) {
   if(keepAlive) keepalive(client);
   encrypt(client);
   client.once('success', onLogin);
-  client.once("compress", onCompressionRequest);
-  client.on("set_compression", onCompressionRequest);
+  compress(client);
   if(haveCredentials) {
     // make a request to get the case-correct username before connecting.
     var cb = function(err, session) {
@@ -99,10 +99,6 @@ function createClient(options) {
     client.write('login_start', {
       username: client.username
     });
-  }
-
-  function onCompressionRequest(packet) {
-    client.compressionThreshold = packet.threshold;
   }
 
   function onLogin(packet) {

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,5 +1,3 @@
-var net = require('net');
-var dns = require('dns');
 var Client = require('./client');
 var assert = require('assert');
 
@@ -9,28 +7,12 @@ var compress = require('./client/compress');
 var caseCorrect = require('./client/caseCorrect');
 var setProtocol = require('./client/setProtocol');
 var play = require('./client/play');
+var tcp_dns = require('./client/tcp_dns');
 
 module.exports=createClient;
 
 function createClient(options) {
   assert.ok(options, "options is required");
-  options.port = options.port || 25565;
-  options.host = options.host || 'localhost';
-
-  options.connect = (client) => {
-    if(options.port == 25565 && net.isIP(host) === 0) {
-      dns.resolveSrv("_minecraft._tcp." + options.host, function(err, addresses) {
-        if(addresses && addresses.length > 0) {
-          client.setSocket(net.connect(addresses[0].port, addresses[0].name));
-        } else {
-          client.setSocket(net.connect(options.port, options.host));
-        }
-      });
-    } else {
-      client.setSocket(net.connect(options.port, options.host));
-    }
-  };
-
   assert.ok(options.username, "username is required");
 
   var optVersion = options.version || require("./version").defaultVersion;
@@ -41,6 +23,7 @@ function createClient(options) {
 
   var client = new Client(false, options.majorVersion);
 
+  tcp_dns(client, options);
   setProtocol(client, options);
   keepalive(client, options);
   encrypt(client);

--- a/src/ping.js
+++ b/src/ping.js
@@ -42,5 +42,6 @@ function ping(options, cb) {
     client.state = states.STATUS;
   });
 
+  // TODO: update
   client.connect(port, host);
 }

--- a/src/ping.js
+++ b/src/ping.js
@@ -1,17 +1,20 @@
 var net = require('net');
 var Client = require('./client');
 var states = require("./states");
+var tcp_dns = require('./client/tcp_dns');
 
 module.exports = ping;
 
 function ping(options, cb) {
-  var host = options.host || 'localhost';
-  var port = options.port || 25565;
+  options.host = options.host || 'localhost';
+  options.port = options.port || 25565;
   var optVersion = options.version || require("./version").defaultVersion;
   var mcData=require("minecraft-data")(optVersion);
   var version = mcData.version;
+  options.majorVersion = version.majorVersion;
+  options.protocolVersion = version.version;
 
-  var client = new Client(false,version.majorVersion);
+  var client = new Client(false,options.majorVersion);
   client.on('error', function(err) {
     cb(err);
   });
@@ -32,16 +35,17 @@ function ping(options, cb) {
       client.write('ping_start', {});
   });
 
+  // TODO: refactor with src/client/setProtocol.js
   client.on('connect', function() {
     client.write('set_protocol', {
-      protocolVersion: version.version,
-      serverHost: host,
-      serverPort: port,
+      protocolVersion: options.protocolVersion,
+      serverHost: options.host,
+      serverPort: options.port,
       nextState: 1
     });
     client.state = states.STATUS;
   });
 
-  // TODO: update
-  client.connect(port, host);
+  tcp_dns(client, options);
+  options.connect(client);
 }


### PR DESCRIPTION
An attempt at beginning to modularize createClient() into separate modular components, see also https://github.com/PrismarineJS/node-minecraft-protocol/pull/210 [WIP] Modularize NMP which covered server, but this PR is for client only. I also did not tackle how to enable/disable/load 'modules' in this PR, considering it out of scope — this is only a source-level refactor/cleanup to make the client more modular.

Note: lots of code moved around, but few actual changes; best reviewed by individual commit, I strived to keep each new module to one commit (but did not meet this goal, had to do some cleanup afterwards, did not bother to rebase/squash, though I could if needed). 

The basic design is each submodule is called with `(client, options)`, and it is responsible for modifying the client to add some functionality, given the optional options object. The goal being to reduce tight coupling, as much as possible, but it could still be improved further. Or the modules could be broken up differently. Currently includes:

* src/client/compress.js: sets compression threshold
 * would like the src/transforms/compression.js transformation to be piped in here; has a hard dependency with other internals not touched here, but ought to be more isolated so can simply remove this module to disable compression entirely
* src/client/caseCorrect.js: gets the case-correct username from yggdrasil before connecting
 * is also responsible for performing the next step - calling connect() - possible to factor this dependency out? if no credentials given, it doesn't case-correct, but still has to call connect() to trigger the next step in the connection process
* src/client/encrypt.js: ursa, yggdrasil, crypto, encryption key request. not extensively tested
* src/client/keepalive.js: listen for `keep_alive`, respond
* src/client/play.js: listen for `success`, transition to `PLAY` state
 * maybe could be renamed, or merged into another module. encrypt? handshake/login?
* src/client/setProtocol.js: sends `set_protocol` packet, this is very interesting from a modularization perspective, since FML|HS would want to change it, as would protocol negotiation add-ons
* src/client/tcp_dns.js: includes creating the TCP/IP socket with `net.connect()` and DNS resolution with `dns.resolveSrv()`
 * this is the biggest change, couldn't come up with a good name for the module, but it performs essential TCP/IP socket networking functions — this is very desirable to factor out, since, for example, a web socket server would not use it, and instead call setSocket() itself; the crucial abstraction here is a nodejs [stream](https://github.com/deathcap/wsmc/blob/master/minecraft-protocol-stream.js)

createClient() still includes the minecraft-data version lookup, but with these changes, the file is not much more than a list of modules to inject:

```javascript
var encrypt = require('./client/encrypt');
var keepalive = require('./client/keepalive');
var compress = require('./client/compress');
var caseCorrect = require('./client/caseCorrect');
var setProtocol = require('./client/setProtocol');
var play = require('./client/play');
var tcp_dns = require('./client/tcp_dns');

module.exports=createClient;

function createClient(options) {
…[version lookup code elided…]

  tcp_dns(client, options);
  setProtocol(client, options);
  keepalive(client, options);
  encrypt(client, options);
  play(client, options);
  compress(client, options);
  caseCorrect(client, options);

  return client;
}
```