### PR TITLE
Server response to legacy ping (fe and fe01) packets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "browser": "browser.js",
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",
+    "endian-toggle": "0.0.0",
     "espower-loader": "^1.0.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",

--- a/src/client.js
+++ b/src/client.js
@@ -14,6 +14,7 @@ class Client extends EventEmitter
     super();
     this.version=version;
     this.isServer = !!isServer;
+    this.splitter=framing.createSplitter();
     this.setSerializer(states.HANDSHAKING);
     this.packetsToParse={};
     this.serializer;
@@ -21,7 +22,6 @@ class Client extends EventEmitter
     this.framer=framing.createFramer();
     this.cipher=null;
     this.decipher=null;
-    this.splitter=framing.createSplitter();
     this.decompressor=null;
     this.deserializer;
     this.isServer;
@@ -51,6 +51,7 @@ class Client extends EventEmitter
     this.deserializer = createDeserializer({ isServer:this.isServer, version:this.version, state: state, packetsToParse:
       this.packetsToParse});
 
+    this.splitter.recognizeLegacyPing = state === states.HANDSHAKING;
 
     this.serializer.on('error', (e) => {
       var parts=e.field.split(".");

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -129,9 +129,15 @@ function createServer(options) {
 
     function onLegacyPing(packet) {
       console.log('onLegacyPing',packet);
-      if (packet.payload === 0) {
-        var responseString = [server.motd, server.playerCount.toString(), server.maxPlayers.toString()].join('\xa7');
 
+      if (packet.payload === 1) {
+        // TODO: ping type 1
+      } else {
+        // ping type 0
+        sendPingResponse([server.motd, server.playerCount.toString(), server.maxPlayers.toString()].join('\xa7'));
+      }
+
+      function sendPingResponse(responseString) {
         function utf16be(s) {
           //var responseBuffer = new Buffer(responseString, 'utf16le'); // unfortunately, we need utf16be not le
           //var responseBuffer = new Buffer(responseString, 'ucs2'); // aliases for utf16le
@@ -149,7 +155,7 @@ function createServer(options) {
 
         client.writeRaw(Buffer.concat([new Buffer('ff', 'hex'), lengthBuffer, responseBuffer]));
       }
-      // TODO: support ping type 1
+
     }
 
     function onLogin(packet) {

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -128,10 +128,10 @@ function createServer(options) {
     }
 
     function onLegacyPing(packet) {
-      console.log('onLegacyPing',packet);
-
       if (packet.payload === 1) {
-        // TODO: ping type 1
+        var pingVersion = 1;
+        sendPingResponse('\xa7' + [pingVersion, version.version, version.minecraftVersion,
+            server.motd, server.playerCount.toString(), server.maxPlayers.toString()].join('\0'));
       } else {
         // ping type 0
         sendPingResponse([server.motd, server.playerCount.toString(), server.maxPlayers.toString()].join('\xa7'));
@@ -153,7 +153,10 @@ function createServer(options) {
         var lengthBuffer = new Buffer(2);
         lengthBuffer.writeUInt16BE(length);
 
-        client.writeRaw(Buffer.concat([new Buffer('ff', 'hex'), lengthBuffer, responseBuffer]));
+        var raw = Buffer.concat([new Buffer('ff', 'hex'), lengthBuffer, responseBuffer]);
+
+        //client.writeRaw(raw); // not raw enough, it includes length
+        client.socket.write(raw);
       }
 
     }

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -5,6 +5,7 @@ var states = require("./states");
 var bufferEqual = require('buffer-equal');
 var Server = require('./server');
 var UUID = require('uuid-1345');
+var endianToggle = require('endian-toggle');
 
 module.exports=createServer;
 
@@ -139,12 +140,7 @@ function createServer(options) {
 
       function sendPingResponse(responseString) {
         function utf16be(s) {
-          //var responseBuffer = new Buffer(responseString, 'utf16le'); // unfortunately, we need utf16be not le
-          //var responseBuffer = new Buffer(responseString, 'ucs2'); // aliases for utf16le
-          // hack semi-UTF16BE encoding, by prefixing each character with a null byte
-          // TODO: use a real encoder, maybe https://github.com/ForbesLindesay/legacy-encoding?
-          // uses https://github.com/ashtuchkin/iconv-lite which has 'utf16-be'. use or separate out?
-          return new Buffer([''].concat(s.split('')).join('\0'), 'binary');
+          return endianToggle(new Buffer(s, 'utf16le'), 16);
         }
 
         var responseBuffer = utf16be(responseString);

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -29,12 +29,12 @@ class Splitter extends Transform {
   constructor() {
     super();
     this.buffer = new Buffer(0);
+    this.recognizeLegacyPing = false;
   }
   _transform(chunk, enc, cb) {
     this.buffer = Buffer.concat([this.buffer, chunk]);
 
-    // TODO: only decode if in handshake state! important since 254 is a valid varint (encodes as 0xfe 0x01), packet length
-    if (this.buffer[0] === LEGACY_PING_PACKET_ID) {
+    if (this.recognizeLegacyPing && this.buffer[0] === LEGACY_PING_PACKET_ID) {
       // legacy_server_list_ping packet follows a different protocol format
       // prefix the encoded varint packet id for the deserializer
       var header = new Buffer(sizeOfVarInt(LEGACY_PING_PACKET_ID));

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -23,6 +23,8 @@ class Framer extends Transform {
   }
 }
 
+const LEGACY_PING_PACKET_ID = 0xfe;
+
 class Splitter extends Transform {
   constructor() {
     super();
@@ -31,9 +33,15 @@ class Splitter extends Transform {
   _transform(chunk, enc, cb) {
     this.buffer = Buffer.concat([this.buffer, chunk]);
 
-    if (this.buffer[0] === 0xfe) {
-      // legacy_server_list_ping packet follows a different protocol format, no varint length
-      this.push(this.buffer);
+    // TODO: only decode if in handshake state! important since 254 is a valid varint (encodes as 0xfe 0x01), packet length
+    if (this.buffer[0] === LEGACY_PING_PACKET_ID) {
+      // legacy_server_list_ping packet follows a different protocol format
+      // prefix the encoded varint packet id for the deserializer
+      var header = new Buffer(sizeOfVarInt(LEGACY_PING_PACKET_ID));
+      writeVarInt(LEGACY_PING_PACKET_ID, header, 0);
+      var payload = this.buffer.slice(1); // remove 0xfe packet id
+      if (payload.length === 0) payload = new Buffer('\0'); // TODO: update minecraft-data to recognize a lone 0xfe, https://github.com/PrismarineJS/minecraft-data/issues/95
+      this.push(Buffer.concat([header, payload]));
       return cb();
     }
 

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -30,6 +30,13 @@ class Splitter extends Transform {
   }
   _transform(chunk, enc, cb) {
     this.buffer = Buffer.concat([this.buffer, chunk]);
+
+    if (this.buffer[0] === 0xfe) {
+      // legacy_server_list_ping packet follows a different protocol format, no varint length
+      this.push(this.buffer);
+      return cb();
+    }
+
     var offset = 0;
 
     var { value, size, error } = readVarInt(this.buffer, offset) || { error: "Not enough data" };


### PR DESCRIPTION
Implements server-side support for https://github.com/PrismarineJS/node-minecraft-protocol/issues/332 FE legacy ping support

Supports type 0 (fe) and type 1 (fe01) pings, testing with https://github.com/deathcap/node-minecraft-ping:

```
node-minecraft-protocol $ NODE_DEBUG=mc-proto node examples/server/server.js
node-minecraft-ping $   node demo.js localhost 25565
received ping_fe01fa { pingVersion: 1,
  protocolVersion: 47,
  gameVersion: '1.8.8',
  motd: 'Vox Industries',
  playersOnline: 0,
  maxPlayers: 12 }
received ping_fe { pingVersion: 0,
  motd: 'Vox Industries',
  playersOnline: 0,
  maxPlayers: 12 }
received ping_fe01 { pingVersion: 1,
  protocolVersion: 47,
  gameVersion: '1.8.8',
  motd: 'Vox Industries',
  playersOnline: 0,
  maxPlayers: 12 }
```

Some notes about issues/limitations with this pull request:

* The deserializer cannot parse legacy ping packets, because of the missing varint packet type header, so I worked around by having the splitter prepend a varint packet id. Ideally minecraft-data could specify how to parse these packets: https://github.com/PrismarineJS/minecraft-data/issues/95 but idk how
* minecraft-data specifies server_legacy_list_ping as requiring a ubyte payload, but for ping type 0 it is not, so I fill in a \0 in the ping payload to avoid deserialization errors. Also would need changes to https://github.com/PrismarineJS/minecraft-data/issues/95
* Serializer is not used to write the ping responses (or the ping requests, which aren't supported in this PR) for the same reason; client.writeRaw() is also unsuitable because it prepends length, so I use client.socket.write(). Maybe this could be refactored further, a new "legacy" packet state, which doesn't have length varints? Could be revisited later if/once pre-Netty protocol support is added.
* ~~Node.js has utf16le support in Buffer but not utf16be (https://github.com/nodejs/node-v0.x-archive/issues/1684); encoded hackishly~~ updated to use native utf16le + swap with https://github.com/substack/endian-toggle, works well
* No client support for sending legacy ping requests or parsing legacy ping responses (can use n-mc-ping, but would be nice to have in nmp)

but it is functional