### PR TITLE
Remove client chat exclusion from server

### DIFF
--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -40,7 +40,7 @@ server.on('login', function(client) {
 
   client.on('chat', function(data) {
     var message = '<' + client.username + '>' + ' ' + data.message;
-    broadcast(message, client, client.username);
+    broadcast(message, null, client.username);
     console.log(message);
   });
 });


### PR DESCRIPTION
The example server supports receiving chat messages, broadcasting to all players, but it excludes the sending user. 

This causes the user to not see their own chat messages (at least on 1.8.9 where I tested, maybe chat was echoed locally in earlier Minecraft versions hence this exclusion?). Removing the exclusion fixes the issue.