### PR TITLE
Log when connection lost in client_echo example

### DIFF
--- a/examples/client_echo/client_echo.js
+++ b/examples/client_echo/client_echo.js
@@ -18,6 +18,9 @@ client.on('connect', function() {
 client.on('disconnect', function(packet) {
   console.log('disconnected: '+ packet.reason);
 });
+client.on('end', function(err) {
+  console.log('Connection lost');
+});
 client.on('chat', function(packet) {
   var jsonMsg = JSON.parse(packet.message);
   if(jsonMsg.translate == 'chat.type.announcement' || jsonMsg.translate == 'chat.type.text') {


### PR DESCRIPTION
Adds a log message on the `end` event in `client_echo`. Without this message, it can be confusing why the program exits without error (if for example, the server forcefully terminates the connection without sending a `disconnect` reason)