### PR TITLE
Fix client_chat example extra array iteration. Closes GH-343

### DIFF
--- a/examples/client_chat/client_chat.js
+++ b/examples/client_chat/client_chat.js
@@ -171,9 +171,11 @@ function parseChat(chatObj, parentState) {
 
       chat += color(util.format.apply(this, args), getColorize(parentState));
     }
-    chatObj.extra.forEach(function(i) {
-      chat += parseChat(chatObj.extra[i], parentState);
-    });
+    if (chatObj.extra) {
+      chatObj.extra.forEach(function(item) {
+        chat += parseChat(item, parentState);
+      });
+    }
     return chat;
   }
 }


### PR DESCRIPTION
examples/client_chat tries to iterate the `extra` array (see reference examples at http://wiki.vg/Chat) using forEach, but the function is called with the array items not the indices (`for ... in` will get the indices, and ES6 `for ... of`will get the items like forEach), so the subscript is undefined causing the error reported in https://github.com/PrismarineJS/node-minecraft-protocol/issues/343 https://gist.github.com/nsporillo/429bddc88896cf147d24. Regressed not long ago as part of some code cleanup https://github.com/PrismarineJS/node-minecraft-protocol/commit/b2b53c93433a599e02b7c23b52f91df988c1a86d

This PR fixes this error by using the array items from forEach, and also adding a check for `chatObj.extra` since it is optional. Resolves the issue according to the discussion in https://github.com/PrismarineJS/node-minecraft-protocol/issues/343