### PR TITLE
[WIP] Compress compressedNbt on write

### DIFF
--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -77,6 +77,7 @@ function writeCompressedNbt(value, buffer, offset) {
   nbt.proto.write(value,nbtBuffer,0,"nbt");
 
   const compressedNbt = zlib.gzipSync(nbtBuffer); // TODO: async
+  compressedNbt.writeUInt8(0, 9); // clear the OS field to match MC
 
   buffer.writeInt16BE(compressedNbt.length,offset);
   compressedNbt.copy(buffer,offset+2);

--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -73,14 +73,26 @@ function writeCompressedNbt(value, buffer, offset) {
     buffer.writeInt16BE(-1,offset);
     return offset+2;
   }
-  buffer.writeInt16BE(sizeOfNbt(value),offset);
-  return nbt.proto.write(value,buffer,offset+2,"nbt");
+  const nbtBuffer = new Buffer(sizeOfNbt(value));
+  nbt.proto.write(value,nbtBuffer,0,"nbt");
+
+  const compressedNbt = zlib.gzipSync(nbtBuffer); // TODO: async
+
+  buffer.writeInt16BE(compressedNbt.length,offset);
+  compressedNbt.copy(buffer,offset+2);
+  return offset+2+compressedNbt.length;
 }
 
 function sizeOfCompressedNbt(value) {
   if(value==undefined)
     return 2;
-  return 2+nbt.proto.sizeOf(value,"nbt");
+
+  const nbtBuffer = new Buffer(sizeOfNbt(value,"nbt"));
+  nbt.proto.write(value,nbtBuffer,0,"nbt");
+
+  const compressedNbt = zlib.gzipSync(nbtBuffer); // TODO: async
+
+  return 2+compressedNbt.length;
 }
 
 


### PR DESCRIPTION
ref https://github.com/PrismarineJS/minecraft-data/pull/104#issuecomment-184570156

Current status:

received from server raw on 1st line, compared to deserialized and reserialized and about to be sent by proxy in 2nd line:

```
3500000093002cffffffdf0100a71f8b0800000000000000458e4d0ac23010859f692d2120287a000fe02dd4858b8ad49dbb940c12d044638b8dd7f052dec2a3c49822ae06be797f026010fb8bbc9b4a9a2321671895da24b2a293f4787d89ecfe249b73f0b56974e3370ac5c19e6b4d0c9328da9274b54f3f4d3714bfeca56d4d833cc3e0114278c7eb012c38985610a5ad938a1cc3b02f9d314c2bbab6da91da4540ae9f378ed62e5a9ff800f1ddc563ba000000
3500000093002cffffffdf0100a71f8b0800000000000003458e4d0ac23010859f692d2120287a000fe02dd4858b8ad49dbb940c12d044638b8dd7f052dec2a3c49822ae06be797f026010fb8bbc9b4a9a2321671895da24b2a293f4787d89ecfe249b73f0b56974e3370ac5c19e6b4d0c9328da9274b54f3f4d3714bfeca56d4d833cc3e0114278c7eb012c38985610a5ad938a1cc3b02f9d314c2bbab6da91da4540ae9f378ed62e5a9ff800f1ddc563ba000000
```

both decompress to:

```
0a000002000a537061776e52616e6765000402000d4d696e537061776e44656c617900c802000d4d6178537061776e44656c61790320080008456e74697479496400065a6f6d6269650200114d61784e6561726279456e746974696573000602000a537061776e436f756e7400040300017affffffdf030001790000002c0800026964000a4d6f62537061776e657202000544656c617900140200135265717569726564506c6179657252616e67650010030001780000009300
```

but the difference is 00 vs 03 in the compressed data stream - what zlib compression options https://nodejs.org/api/zlib.html#zlib_class_options do we need to match vanilla exactly?