### PR TITLE
[WIP] 1.7 protocol support in node-minecraft-protocol

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -253,8 +253,10 @@ function createServer(options) {
       if(onlineMode == false || isException) {
         client.uuid = nameToMcOfflineUUID(client.username);
       }
-      client.write('compress', { threshold: 256 }); // Default threshold is 256
-      client.compressionThreshold = 256;
+      if (version.version >= 27) { // 14w28a (27) added whole-protocol compression (http://wiki.vg/Protocol_History#14w28a), earlier versions per-packet compressed TODO: refactor into minecraft-data
+        client.write('compress', { threshold: 256 }); // Default threshold is 256
+        client.compressionThreshold = 256;
+      }
       client.write('success', {uuid: client.uuid, username: client.username});
       client.state = states.PLAY;
       loggedIn = true;


### PR DESCRIPTION
Changes to node-minecraft-protocol to enable 1.7 protocol support (testing with 1.7.10)

Requires:

* https://github.com/PrismarineJS/minecraft-data/pull/104
* https://github.com/PrismarineJS/node-minecraft-data/pull/19

Currently hardcoding the version where whole-protocol compression was added, but probably a better solution should be devised (maybe adding "uses/doesn't use whole protocol compression" to somewhere in minecraft-data per protocol version, and having node-minecraft-protocol honor it).