### PR TITLE
Fixed options.favicon in createServer

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -37,6 +37,7 @@ function createServer(options) {
   server.maxPlayers = options['max-players'] || 20;
   server.playerCount = 0;
   server.onlineModeExceptions = {};
+  server.favicon = options.favicon || 0;
   server.on("connection", function(client) {
     client.once('set_protocol', onHandshake);
     client.once('login_start', onLogin);


### PR DESCRIPTION
- if the server is created with option "favicon" (base64 encoded image string), it now loads it into the server object inside "createServer", and passes it on to the "response" object used in the "onPing" function. If it is empty, it is set to 0. Tested working.