### PR TITLE
Enable strict mode

### DIFF
--- a/examples/client_auto/client_auto.js
+++ b/examples/client_auto/client_auto.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var mc = require('minecraft-protocol');
 
 if(process.argv.length < 4 || process.argv.length > 6) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Client = require('./client');
 const Server = require('./server');
 const serializer = require("./transforms/serializer");

--- a/src/client.js
+++ b/src/client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
 const debug = require('debug')('minecraft-protocol');
 const compression = require('./transforms/compression');

--- a/src/client/autoVersion.js
+++ b/src/client/autoVersion.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ping = require('../ping');
 const debug = require('debug')('minecraft-protocol');
 const states = require('../states');

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const crypto = require('crypto');
 const yggserver = require('yggdrasil').server({});
 const ursa=require("../ursa");

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(client, options) {
   const keepAlive = options.keepAlive == null ? true : options.keepAlive;
   if (!keepAlive) return;

--- a/src/client/setProtocol.js
+++ b/src/client/setProtocol.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const states = require("../states");
 
 module.exports = function(client, options) {

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,6 +1,7 @@
+'use strict';
+
 const Client = require('./client');
 const assert = require('assert');
-
 
 const encrypt = require('./client/encrypt');
 const keepalive = require('./client/keepalive');

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ursa=require("./ursa");
 const crypto = require('crypto');
 const yggserver = require('yggdrasil').server({});

--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const nbt = require('prismarine-nbt');
 const UUID = require('uuid-1345');
 const zlib = require('zlib');

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Client = require('./client');
 const Server = require('./server');
 const serializer = require("./transforms/serializer");

--- a/src/ping.js
+++ b/src/ping.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const net = require('net');
 const Client = require('./client');
 const states = require("./states");

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const net = require('net');
 const EventEmitter = require('events').EventEmitter;
 const Client = require('./client');

--- a/src/states.js
+++ b/src/states.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const states = {
   "HANDSHAKING": "handshaking",
   "STATUS": "status",

--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const [readVarInt, writeVarInt, sizeOfVarInt] = require("protodef").types.varint;
 const zlib = require("zlib");
 const Transform = require("readable-stream").Transform;

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const [readVarInt, writeVarInt, sizeOfVarInt] = require("protodef").types.varint;
 const Transform = require("readable-stream").Transform;
 

--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ProtoDef = require("protodef").ProtoDef;
 const Serializer = require("protodef").Serializer;
 const Parser = require("protodef").Parser;

--- a/src/ursa.js
+++ b/src/ursa.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let ursa;
 try {
   ursa = require("ursa");

--- a/src/version.js
+++ b/src/version.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports={
   defaultVersion:'1.8',
   supportedVersions:['1.7','1.8','15w40b','1.9']


### PR DESCRIPTION
Adds "use strict" to all sources. This adds additional strictness which can help find bugs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FFunctions_and_function_scope%2FStrict_mode

Split out from https://github.com/PrismarineJS/node-minecraft-protocol/pull/319 Use native node.js ES6 support