### PR TITLE
Changed let scope, added undefined check.

### DIFF
--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -41,7 +41,8 @@ let printAllNames = false;
 const printNameWhitelist = {};
 const printNameBlacklist = {};
 (function() {
-  for(let i = 0; i < args.length; i++) {
+  let i = 0;
+  for(i = 0; i < args.length; i++) {
     const option = args[i];
     if(!/^-/.test(option)) break;
     if(option === "--dump-all") {
@@ -180,6 +181,6 @@ function shouldDump(name, direction) {
   return matches(printNameWhitelist[name]);
 
   function matches(result) {
-    return result !== null && result.indexOf(direction) !== -1;
+    return result !== undefined && result !== null && result.indexOf(direction) !== -1;
   }
 }


### PR DESCRIPTION
I was using the example proxy because I wanted to figure out how the scoreboard protocol worked, and this one has the nifty dump feature, and got some errors running the proxy because the let is referenced in the if statement after the for loop, and also because sometimes result can be undefined in matches().

These changes got it working for me.

Thanks,
Lane
