### PR TITLE
Emit errors instead of throwing.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -194,7 +194,7 @@ class Client extends EventEmitter
 
   setEncryption(sharedSecret) {
     if (this.cipher != null)
-      throw new Error("Set encryption twice !");
+      this.emit('error','Set encryption twice!');
     this.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret);
     this.cipher.on('error', (err) => this.emit('error', err));
     this.framer.unpipe(this.socket);

--- a/src/client.js
+++ b/src/client.js
@@ -194,7 +194,7 @@ class Client extends EventEmitter
 
   setEncryption(sharedSecret) {
     if (this.cipher != null)
-      this.emit('error','Set encryption twice!');
+      this.emit('error', new Error('Set encryption twice!'));
     this.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret);
     this.cipher.on('error', (err) => this.emit('error', err));
     this.framer.unpipe(this.socket);

--- a/src/client/autoVersion.js
+++ b/src/client/autoVersion.js
@@ -30,7 +30,7 @@ module.exports = function(client, options) {
     .sort(function (a, b) { return b.version - a.version })
     .concat(minecraft_data.postNettyVersionsByProtocolVersion["pc"][protocolVersion]||[])
     if (versions.length === 0) {
-      client.emit('error',`unsupported/unknown protocol version: ${protocolVersion}, update minecraft-data`);
+      client.emit('error', new Error(`unsupported/unknown protocol version: ${protocolVersion}, update minecraft-data`));
     }
     const minecraftVersion = versions[0].minecraftVersion;
 

--- a/src/client/autoVersion.js
+++ b/src/client/autoVersion.js
@@ -11,7 +11,7 @@ module.exports = function(client, options) {
   debug('pinging',options.host);
   // TODO: use 0xfe ping instead for better compatibility/performance? https://github.com/deathcap/node-minecraft-ping
   ping(options, function(err, response) {
-    if (err) throw err; // hmm
+    client.emit('error',err);
     debug('ping response',response);
     // TODO: could also use ping pre-connect to save description, type, max players, etc.
     const motd = response.description;
@@ -30,7 +30,7 @@ module.exports = function(client, options) {
     .sort(function (a, b) { return b.version - a.version })
     .concat(minecraft_data.postNettyVersionsByProtocolVersion["pc"][protocolVersion]||[])
     if (versions.length === 0) {
-      throw new Error(`unsupported/unknown protocol version: ${protocolVersion}, update minecraft-data`);
+      client.emit('error',`unsupported/unknown protocol version: ${protocolVersion}, update minecraft-data`);
     }
     const minecraftVersion = versions[0].minecraftVersion;
 


### PR DESCRIPTION
It's probably good to prevent connected clients from crashing servers at all costs, for obvious reasons. :)

#538 