### PR TITLE
Resolve issue with refreshing sessions

### DIFF
--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -25,7 +25,7 @@ module.exports = function(client, options) {
         if (!err)
           cb(null, options.session);
         else
-          yggdrasil.refresh(options.session.accessToken, options.session.clientToken, function(err, data) {
+          yggdrasil.refresh(options.session.accessToken, options.session.clientToken, function(err, accessToken, data) {
             if (!err) {
               cb(null, data);
             } else if (options.username && options.password) {


### PR DESCRIPTION
Resolves issue whereby access token was passed to callback instead of the session object, causing an unhandled error.