### PR TITLE
1.13 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "espower-loader": "^1.0.0",
     "intelli-espower-loader": "^1.0.0",
-    "minecraft-wrap": "^1.0.0",
+    "minecraft-wrap": "^1.2.0",
     "mocha": "^5.0.5",
     "power-assert": "^1.0.0",
     "require-self": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "endian-toggle": "^0.0.0",
     "lodash.get": "^4.1.2",
     "lodash.merge": "^4.3.0",
-    "minecraft-data": "^2.26.0",
+    "minecraft-data": "^2.27.0",
     "node-rsa": "^0.4.2",
     "prismarine-nbt": "^1.2.0",
     "protodef": "^1.6.7",

--- a/src/version.js
+++ b/src/version.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   defaultVersion: '1.12.2',
-  supportedVersions: ['1.7', '1.8', '1.9', '1.10', '1.11.2', '1.12.2', '17w50a']
+  supportedVersions: ['1.7', '1.8', '1.9', '1.10', '1.11.2', '1.12.2', '1.13']
 }

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -13,6 +13,25 @@ function evalCount (count, fields) {
   return count['default']
 }
 
+const slotValue = {
+  blockId: 5,
+  itemCount: 56,
+  itemDamage: 2,
+  nbtData: {
+    type: 'compound',
+    name: 'test',
+    value: {
+      test1: {type: 'int', value: 4},
+      test2: {type: 'long', value: [12, 42]},
+      test3: {type: 'byteArray', value: [32]},
+      test4: {type: 'string', value: 'ohi'},
+      test5: {type: 'list', value: {type: 'int', value: [4]}},
+      test6: {type: 'compound', value: {test: {type: 'int', value: 4}}},
+      test7: {type: 'intArray', value: [12, 42]}
+    }
+  }
+}
+
 const values = {
   'i32': 123456,
   'i16': -123,
@@ -61,24 +80,7 @@ const values = {
   'bool': true,
   'f64': 99999.2222,
   'f32': -333.444,
-  'slot': {
-    blockId: 5,
-    itemCount: 56,
-    itemDamage: 2,
-    nbtData: {
-      type: 'compound',
-      name: 'test',
-      value: {
-        test1: {type: 'int', value: 4},
-        test2: {type: 'long', value: [12, 42]},
-        test3: {type: 'byteArray', value: [32]},
-        test4: {type: 'string', value: 'ohi'},
-        test5: {type: 'list', value: {type: 'int', value: [4]}},
-        test6: {type: 'compound', value: {test: {type: 'int', value: 4}}},
-        test7: {type: 'intArray', value: [12, 42]}
-      }
-    }
-  },
+  'slot': slotValue,
   'nbt': {
     type: 'compound',
     name: 'test',
@@ -156,7 +158,9 @@ const values = {
     })
     return results
   },
-  'tags': [{'tagName': 'hi', 'entries': [1, 2, 3, 4, 5]}]
+  'tags': [{'tagName': 'hi', 'entries': [1, 2, 3, 4, 5]}],
+  'ingredient': [slotValue],
+  'particleData': null
 }
 
 function getValue (_type, packet) {


### PR DESCRIPTION
to fix #576

missing : 
* [x] fix node-minecraft-wrap to use the new server url (adapt the code to run the client which is the proper way to download minecraft assets)
* [x] run the tests with the server downloaded