### PR TITLE
Updated typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { Socket } from 'net'
 import * as Stream from 'stream'
+import { on } from 'cluster';
 
 declare module 'minecraft-protocol' {
 	export class Client extends EventEmitter {
@@ -18,6 +19,7 @@ declare module 'minecraft-protocol' {
 		unregisterChannel(name: string): void
 		write(name: string, params: any): void
 		writeChannel(channel: any, params: any): void
+		on(event: 'error', listener: (error: Error) => void): this
 		on(event: 'packet', handler: (data: any, packetMeta: PacketMeta) => void): this
 		on(event: 'raw', handler: (data: any, packetMeta: PacketMeta) => void): this
 		on(event: 'session', handler: (session: any) => void): this
@@ -47,6 +49,7 @@ declare module 'minecraft-protocol' {
 		onlineModeExceptions: object
 		playerCount: number
 		on(event: 'connection', handler: (client: Client) => void): this
+		on(event: 'error', listener: (error: Error) => void): this
 		on(event: 'login', handler: (client: Client) => void): this
 	}
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,138 +1,140 @@
-import {Socket} from 'net'
+import { EventEmitter } from 'events';
+import { Socket } from 'net'
 import * as Stream from 'stream'
-import EventEmitter = NodeJS.EventEmitter
 
-declare enum EnumStates {
-  HANDSHAKING = 'handshaking',
-  STATUS = 'status',
-  LOGIN = 'login',
-  PLAY = 'play',
+declare module 'minecraft-protocol' {
+	export class Client extends EventEmitter {
+		constructor(isServer: boolean, version: string, customPackets?: any)
+		isServer: boolean
+		latency: number
+		profile: any
+		session: any
+		socket: Socket
+		state: States
+		username: string
+		uuid: string
+		end(reason: string): void
+		registerChannel(name: string, typeDefinition: any, custom?: boolean): void
+		unregisterChannel(name: string): void
+		write(name: string, params: any): void
+		writeChannel(channel: any, params: any): void
+		on(event: 'packet', handler: (data: any, packetMeta: PacketMeta) => void): this
+		on(event: 'raw', handler: (data: any, packetMeta: PacketMeta) => void): this
+		on(event: 'session', handler: (session: any) => void): this
+		on(event: 'state', handler: (newState: States, oldState: States) => void): this
+	}
+
+	export interface ClientOptions {
+		accessToken?: string
+		checkTimeoutInterval?: number
+		clientToken?: string
+		customPackets?: any
+		hideErrors?: boolean
+		host?: string
+		keepAlive?: boolean
+		password?: string
+		port?: number
+		username: string
+		version?: string
+	}
+
+	export class Server extends EventEmitter {
+		constructor(version: string, customPackets?: any)
+		clients: ClientsMap
+		favicon: string
+		maxPlayers: number
+		motd: string
+		onlineModeExceptions: object
+		playerCount: number
+		on(event: 'connection', handler: (client: Client) => void): this
+		on(event: 'login', handler: (client: Client) => void): this
+	}
+
+	export interface ServerOptions {
+		'online-mode'?: boolean
+		checkTimeoutInterval?: number
+		customPackets?: any
+		hideErrors?: boolean
+		host?: string
+		keepAlive?: boolean
+		kickTimeout?: number
+		maxPlayers?: number
+		motd?: string
+		port?: number
+		stream?: Stream
+		version?: string
+		beforePing?: (response: any, client: Client, callback?: (result: any) => any) => any
+		connect?: (client: Client) => void
+		errorHandler?: (client: Client, error: Error) => void
+	}
+
+	export interface SerializerOptions {
+		customPackets: any
+		isServer?: boolean
+		state?: States
+		version: string
+	}
+
+	enum States {
+		HANDSHAKING = 'handshaking',
+		LOGIN = 'login',
+		PLAY = 'play',
+		STATUS = 'status',
+	}
+
+	export interface PacketMeta {
+		name: string
+		state: States
+	}
+
+	interface ClientsMap {
+		[key: string]: Client
+	}
+
+	export interface PingOptions {
+		host?: string
+		majorVersion?: string
+		port?: number
+		protocolVersion?: string
+		version?: string
+	}
+
+	export interface OldPingResult {
+		maxPlayers: number,
+		motd: string
+		playerCount: number
+		prefix: string
+		protocol: string
+		version: string
+	}
+
+	export interface NewPingResult {
+		description: string
+		players: {
+			max: number
+			online: number
+			sample: {
+				id: string
+				name: string
+			}[]
+		}
+		version: {
+			name: string
+			protocol: string
+		}
+		favicon: string
+		latency: number
+	}
+
+	export const state: States
+	export const supportedVersions: ['1.7', '1.8', '1.9', '1.10', '1.11.2', '1.12.2', '1.13.1']
+
+	export function createServer(options: ServerOptions): Server
+	export function createClient(options: ClientOptions): Client
+
+	// TODO: Create typings on protodef to define here
+	export function createSerializer({ state, isServer, version, customPackets }: SerializerOptions): any
+	export function createDeserializer({ state, isServer, version, customPackets }: SerializerOptions): any
+
+	export function ping(options: PingOptions, callback: (error: Error, result: OldPingResult | NewPingResult) => void): void
 }
-
-export interface IPacketMeta {
-  name: string
-  state: EnumStates
-}
-
-export declare class Client extends EventEmitter {
-  constructor(isServer: boolean, version: string, customPackets?: any)
-  write(name: string, params: any)
-  end(reason: string)
-  state: EnumStates
-  isServer: boolean
-  socket: Socket
-  uuid: string
-  username: string
-  session: any
-  profile: any
-  latency: number
-  on(event: 'packet', handler: (data: any, packetMeta: IPacketMeta) => any)
-  on(event: 'raw', handler: (data: any, packetMeta: IPacketMeta) => any)
-  on(event: 'state', handler: (newState: EnumStates, oldState: EnumStates) => any)
-  on(event: 'session', handler: (session: any) => any)
-  writeChannel(channel: any, params: any)
-  registerChannel(name: string, typeDefinition: any, custom?: boolean)
-  unregisterChannel(name: string)
-}
-
-interface IClientsMap {
-  [key: string]: Client
-}
-
-export declare class Server extends EventEmitter {
-  constructor(version: string, customPackets?: any)
-  onlineModeExceptions: object
-  clients: IClientsMap
-  playerCount: number
-  maxPlayers: number
-  motd: string
-  favicon: string
-  on(event: 'connection', handler: (client: Client) => any)
-  on(event: 'login', handler: (client: Client) => any)
-}
-
-export interface ICreateServerOptions {
-  host?: string
-  port?: number
-  kickTimeout?: number
-  checkTimeoutInterval?: number
-  'online-mode'?: boolean
-  motd?: string
-  maxPlayers?: number
-  keepAlive?: boolean
-  version?: string
-  customPackets?: any
-  stream?: Stream
-  beforePing?: (response: any, client: Client, callback?: (result: any) => any) => any
-  errorHandler?: (client: Client, error: Error) => any
-  connect?: (client: Client) => any
-  hideErrors?: boolean
-}
-
-export interface ICreateClientOptions {
-  username: string
-  port?: number
-  password?: string
-  host?: string
-  clientToken?: string
-  accessToken?: string
-  keepAlive?: boolean
-  checkTimeoutInterval?: number
-  version?: string
-  customPackets?: any
-  hideErrors?: boolean
-}
-
-export interface ICreateSerializerOptions {
-  state?: EnumStates
-  isServer?: boolean
-  version: string
-  customPackets: any
-}
-
-export interface IPingOptions {
-  host?: string
-  port?: number
-  version?: string
-  majorVersion?: string
-  protocolVersion?: string
-}
-
-export interface IPingOldResult {
-  prefix: string
-  protocol: string
-  version: string
-  motd: string
-  playerCount: number
-  maxPlayers: number,
-}
-
-export interface IPingNewResult {
-  description: string
-  players: {
-    max: number
-    online: number
-    sample: {
-      id: string
-      name: string
-    }[]
-  }
-  version: {
-    name: string
-    protocol: string
-  }
-  favicon: string
-  latency: number
-}
-
-export declare function createServer(options: ICreateServerOptions): Server
-export declare function createClient(options: ICreateClientOptions): Client
-
-export const state: EnumStates
-
-export declare function createSerializer({state, isServer, version, customPackets}: ICreateSerializerOptions)
-export declare function createDeserializer({state, isServer, version, customPackets}: ICreateSerializerOptions)
-
-export declare function ping(options: IPingOptions, callback: (err: Error, result: IPingOldResult | IPingNewResult) => any);
-
-export const supportedVersions: string[]


### PR DESCRIPTION
Removed I from interfaces.
Renamed interfaces to be more clear.
Added TODO: Create typings on protodef to define here.
Added supportedVersions static strings.
Rearranged order of exports and properties.
Changed unused returns of functions from any to void (More strict).
Put entire typings inside module declaration.

Now works in strict mode.
Suggestion: Add typings to protodef so createSerializer and createDeserializer have valid types.