### PR TITLE
Update compression.js

### DIFF
--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -52,7 +52,7 @@ class Decompressor extends Transform {
       this.push(chunk.slice(size))
       return cb()
     } else {
-      zlib.inflate(chunk.slice(size), (err, newBuf) => {
+      zlib.unzip(chunk.slice(size), { finishFlush: zlib.constants.Z_SYNC_FLUSH }, (err, newBuf) => { /** Fix by lefela4. */
         if (err) {
           if (!this.hideErrors) {
             console.error('problem inflating chunk')


### PR DESCRIPTION
Ok. The issue is in the minecraft-protocol module, in compression.js line 55.

You need to replace this:
```js
zlib.inflate(chunk.slice(size), (err, newBuf) => {
```
to this:
```js
zlib.unzip(chunk.slice(size), { finishFlush: zlib.constants.Z_SYNC_FLUSH }, (err, newBuf) => { /** Fix by lefela4. */
```

The problem happen when the packet end with the byte 0000ffff. I made some rechearch and I figured out the those byte are made for sharing deflate-compressed data chunks between streaming HTTP clients. However, from my understanding of DEFLATE/zlib, you can instead send Z_FULL_FLUSH 0x0000FFFF bytes to reset the stream which should serve the same effect of individually decompressible chunks. I will sumbit a pull request for the issue. Hope my explanation are good!
Have a good day :)