### PR TITLE
Fix crash when pinging with an unsupported version

### DIFF
--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -17,6 +17,10 @@ function createProtocol (state, direction, version, customPackets) {
   const proto = new ProtoDef(false)
   proto.addTypes(minecraft)
   const mcData = require('minecraft-data')(version)
+  if (mcData === null) {
+    // Unsupported protocol
+    return createProtocol(state, direction, "1.13.2", customPackets)
+  }
   proto.addProtocol(merge(mcData.protocol, get(customPackets, [mcData.version.majorVersion])), [state, direction])
   protocols[key] = proto
   return proto


### PR DESCRIPTION
This library will crash if you ping a server created with it using an unsupported Minecraft version (Tested with the latest 1.14 snapshot 19w09a). This will fix it and stop it from crashing.