### PR TITLE
Get the actual socket object from Socks#CreateConnection

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -142,7 +142,7 @@ class Client extends EventEmitter {
 
     const onError = (err) => this.emit('error', err)
 
-    this.socket = socket
+    this.socket = socket.socket
 
     if (this.socket.setNoDelay) { this.socket.setNoDelay(true) }
 


### PR DESCRIPTION
In newer versions of socks, we need to obtain the socks object from setSocket(), as CreateConnection does not automatically supply it. (This will make the socks example work in examples/)