### PR TITLE
socket end timeout

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,8 @@ const states = require('./states')
 const createSerializer = require('./transforms/serializer').createSerializer
 const createDeserializer = require('./transforms/serializer').createDeserializer
 
+const closeTimeout = 5 * 1000
+
 class Client extends EventEmitter {
   constructor (isServer, version, customPackets, hideErrors = false) {
     super()
@@ -26,6 +28,7 @@ class Client extends EventEmitter {
     this.ended = true
     this.latency = 0
     this.hideErrors = hideErrors
+    this.closeTimer = null
 
     this.state = states.HANDSHAKING
   }
@@ -131,6 +134,7 @@ class Client extends EventEmitter {
     const endSocket = () => {
       if (this.ended) return
       this.ended = true
+      clearTimeout(this.closeTimer)
       this.socket.removeListener('close', endSocket)
       this.socket.removeListener('end', endSocket)
       this.socket.removeListener('timeout', endSocket)
@@ -165,7 +169,13 @@ class Client extends EventEmitter {
     this._endReason = reason
     if (this.cipher) this.cipher.unpipe()
     if (this.framer) this.framer.unpipe()
-    if (this.socket) this.socket.end()
+    if (this.socket) {
+      this.socket.end()
+      this.closeTimer = setTimeout(
+          this.socket.destroy.bind(this.socket),
+          closeTimeout
+      )
+    }
   }
 
   setEncryption (sharedSecret) {

--- a/src/client.js
+++ b/src/client.js
@@ -172,8 +172,8 @@ class Client extends EventEmitter {
     if (this.socket) {
       this.socket.end()
       this.closeTimer = setTimeout(
-          this.socket.destroy.bind(this.socket),
-          closeTimeout
+        this.socket.destroy.bind(this.socket),
+        closeTimeout
       )
     }
   }

--- a/src/client.js
+++ b/src/client.js
@@ -10,7 +10,7 @@ const states = require('./states')
 const createSerializer = require('./transforms/serializer').createSerializer
 const createDeserializer = require('./transforms/serializer').createDeserializer
 
-const closeTimeout = 5 * 1000
+const closeTimeout = 30 * 1000
 
 class Client extends EventEmitter {
   constructor (isServer, version, customPackets, hideErrors = false) {


### PR DESCRIPTION
Currently, calling `client.end()` might result in a hanging socket if the other side doesn't send back the FIN packet. On a server, this is a potential memory leak and can even result in crashes due to open file limits. I don't know what's the best solution for this problem, I've adapted the [solution](https://github.com/websockets/ws/blob/master/lib/websocket.js) from the `ws` library, which works fine.