### PR TITLE
Fix error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ client.on('chat', function(packet) {
     var username = jsonMsg.with[0].text;
     var msg = jsonMsg.with[1];
     if(username === client.username) return;
-    client.write('chat', {message: msg});
+    client.write('chat', {message: msg.text});
   }
 });
 ```

--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -4,6 +4,12 @@ const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 const zlib = require('zlib')
 const Transform = require('readable-stream').Transform
 
+if (zlib.constants.Z_SYNC_FLUSH) {
+  Z_SYNC_FLUSH = zlib.constants.Z_SYNC_FLUSH;
+} else {
+  Z_SYNC_FLUSH = 2;
+}
+
 module.exports.createCompressor = function (threshold) {
   return new Compressor(threshold)
 }
@@ -52,7 +58,7 @@ class Decompressor extends Transform {
       this.push(chunk.slice(size))
       return cb()
     } else {
-      zlib.unzip(chunk.slice(size), { finishFlush: zlib.constants.Z_SYNC_FLUSH }, (err, newBuf) => { /** Fix by lefela4. */
+      zlib.unzip(chunk.slice(size), { finishFlush: Z_SYNC_FLUSH }, (err, newBuf) => { /** Fix by lefela4. */
         if (err) {
           if (!this.hideErrors) {
             console.error('problem inflating chunk')

--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -52,7 +52,7 @@ class Decompressor extends Transform {
       this.push(chunk.slice(size))
       return cb()
     } else {
-      zlib.unzip(chunk.slice(size), { finishFlush: (Z_SYNC_FLUSH) ? Z_SYNC_FLUSH : 2 }, (err, newBuf) => { /** Fix by lefela4. */
+      zlib.unzip(chunk.slice(size), { finishFlush: 2 /*  Z_SYNC_FLUSH = 2, but when using Browserify/Webpack it doesn't exist */ }, (err, newBuf) => { /** Fix by lefela4. */
         if (err) {
           if (!this.hideErrors) {
             console.error('problem inflating chunk')

--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -4,12 +4,6 @@ const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 const zlib = require('zlib')
 const Transform = require('readable-stream').Transform
 
-if (zlib.constants) { // Doesn't exist in Browserify/Webpack
-  Z_SYNC_FLUSH = zlib.constants.Z_SYNC_FLUSH;
-} else {
-  Z_SYNC_FLUSH = 2;
-}
-
 module.exports.createCompressor = function (threshold) {
   return new Compressor(threshold)
 }
@@ -58,7 +52,7 @@ class Decompressor extends Transform {
       this.push(chunk.slice(size))
       return cb()
     } else {
-      zlib.unzip(chunk.slice(size), { finishFlush: Z_SYNC_FLUSH }, (err, newBuf) => { /** Fix by lefela4. */
+      zlib.unzip(chunk.slice(size), { finishFlush: (Z_SYNC_FLUSH) ? Z_SYNC_FLUSH : 2 }, (err, newBuf) => { /** Fix by lefela4. */
         if (err) {
           if (!this.hideErrors) {
             console.error('problem inflating chunk')

--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -4,7 +4,7 @@ const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 const zlib = require('zlib')
 const Transform = require('readable-stream').Transform
 
-if (zlib.constants.Z_SYNC_FLUSH) {
+if (zlib.constants) { // Doesn't exist in Browserify/Webpack
   Z_SYNC_FLUSH = zlib.constants.Z_SYNC_FLUSH;
 } else {
   Z_SYNC_FLUSH = 2;


### PR DESCRIPTION
This fixes an error that occurs with the example echo client:
```TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Object```
This change might be needed in the server as well, but I didn't test that. Or maybe there's a better way to fix this