### PR TITLE
datatypes: properly support optvarints for elytra flying

### DIFF
--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -6,7 +6,7 @@ const zlib = require('zlib')
 const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 
 module.exports = {
-  optvarint: [readOptionalVarInt, writeOptionalVarInt, sizeOfVarInt],
+  optvarint: [readOptionalVarInt, writeOptionalVarInt, sizeOfOptionalVarInt],
   UUID: [readUUID, writeUUID, 16],
   nbt: [readNbt, writeNbt, sizeOfNbt],
   optionalNbt: [readOptionalNbt, writeOptionalNbt, sizeOfOptionalNbt],
@@ -17,9 +17,9 @@ module.exports = {
 var PartialReadError = require('protodef').utils.PartialReadError
 
 // optvarint is: 0 for undefined, all other values encoded as actual value +1
-function readOptionalVarInt(buffer, offset) {
+function readOptionalVarInt (buffer, offset) {
   const varint = readVarInt(buffer, offset)
-  if(varint.value == 0) {
+  if (varint.value === 0) {
     varint.value = undefined
     return varint
   } else {
@@ -28,8 +28,8 @@ function readOptionalVarInt(buffer, offset) {
   }
 }
 
-function writeOptionalVarInt(value, buffer, offset) {
-  if(value === undefined) {
+function writeOptionalVarInt (value, buffer, offset) {
+  if (value === undefined) {
     value = 0
   } else {
     value++
@@ -37,8 +37,8 @@ function writeOptionalVarInt(value, buffer, offset) {
   return writeVarInt(value, buffer, offset)
 }
 
-function sizeOfOptionalVarInt(value) {
-  if(value === undefined) {
+function sizeOfOptionalVarInt (value) {
+  if (value === undefined) {
     value = 0
   } else {
     value++


### PR DESCRIPTION
See prismarinejs/minecraft-data#280, adds support for the `optvarints` referenced there