### PR TITLE
Create index.js which redirects to src/index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/index.js')


### PR DESCRIPTION
Older versions of node.js won't read package.json main parameter. This will fix it.