### PR TITLE
Fallback to Aes-js if no aes-128-cfb8 in crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "protodef": "^1.8.0",
     "readable-stream": "^3.0.6",
     "uuid-1345": "^1.0.1"
+  },
+  "optionalDependencies": {
+    "aes-js": "^3.1.2"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -4,11 +4,13 @@ const EventEmitter = require('events').EventEmitter
 const debug = require('debug')('minecraft-protocol')
 const compression = require('./transforms/compression')
 const framing = require('./transforms/framing')
-const crypto = require('crypto')
 const states = require('./states')
 
 const createSerializer = require('./transforms/serializer').createSerializer
 const createDeserializer = require('./transforms/serializer').createDeserializer
+
+const createCipher = require('./transforms/encryption').createCipher
+const createDecipher = require('./transforms/encryption').createDecipher
 
 const closeTimeout = 30 * 1000
 
@@ -181,11 +183,11 @@ class Client extends EventEmitter {
 
   setEncryption (sharedSecret) {
     if (this.cipher != null) { this.emit('error', new Error('Set encryption twice!')) }
-    this.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.cipher = createCipher(sharedSecret)
     this.cipher.on('error', (err) => this.emit('error', err))
     this.framer.unpipe(this.socket)
     this.framer.pipe(this.cipher).pipe(this.socket)
-    this.decipher = crypto.createDecipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.decipher = createDecipher(sharedSecret)
     this.decipher.on('error', (err) => this.emit('error', err))
     this.socket.unpipe(this.splitter)
     this.socket.pipe(this.decipher).pipe(this.splitter)

--- a/src/transforms/encryption.js
+++ b/src/transforms/encryption.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const crypto = require('crypto')
+const { Transform } = require('readable-stream')
+
+if (!crypto.getCiphers().includes('aes-128-cfb8')) {
+  const Cfb = require('aes-js').ModeOfOperation.cfb
+
+  class Cipher extends Transform {
+    constructor (sharedSecret) {
+      super()
+      this.aes = new Cfb(sharedSecret, sharedSecret, 8)
+    }
+
+    _transform (chunk, encoding, callback) {
+      try {
+        callback(null, this.aes.encrypt(Buffer.concat([chunk, Buffer.alloc(chunk.length % 8)])))
+      } catch (exception) {
+        callback(exception)
+      }
+    }
+  }
+
+  class Decipher extends Transform {
+    constructor (sharedSecret) {
+      super()
+      this.aes = new Cfb(sharedSecret, sharedSecret, 8)
+    }
+
+    _transform (chunk, encoding, callback) {
+      try {
+        callback(null, this.aes.decrypt(Buffer.concat([chunk, Buffer.alloc(chunk.length % 8)])))
+      } catch (exception) {
+        callback(exception)
+      }
+    }
+  }
+
+  module.exports.createCipher = function (sharedSecret) {
+    return new Cipher(sharedSecret)
+  }
+
+  module.exports.createDecipher = function (sharedSecret) {
+    return new Decipher(sharedSecret)
+  }
+} else {
+  module.exports.createCipher = function (sharedSecret) {
+    return crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+  }
+
+  module.exports.createDecipher = function (sharedSecret) {
+    return crypto.createDecipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+  }
+}


### PR DESCRIPTION
for BoringSSL-based environments such as Electron

I did some limited testing on this, but I'm not entirely certain if it's a good implementation. I'll have to do more extensive testing at a later time.