### PR TITLE
Cipher Fallback using crypto-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "yggdrasil": "^1.3.0",
     "buffer-equal": "^1.0.0",
+    "crypto-js": "^4.0.0",
+    "cryptojs-extension": "github:timonschiffmann/cryptojs-extension",
     "debug": "^4.1.0",
     "endian-toggle": "^0.0.0",
     "lodash.get": "^4.1.2",
@@ -54,6 +55,7 @@
     "prismarine-nbt": "^1.3.0",
     "protodef": "^1.8.0",
     "readable-stream": "^3.0.6",
-    "uuid-1345": "^1.0.1"
+    "uuid-1345": "^1.0.1",
+    "yggdrasil": "^1.3.0"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -7,8 +7,8 @@ const framing = require('./transforms/framing')
 const crypto = require('crypto')
 const states = require('./states')
 
-const createSerializer = require('./transforms/serializer').createSerializer
-const createDeserializer = require('./transforms/serializer').createDeserializer
+const { createSerializer, createDeserializer } = require('./transforms/serializer')
+const { createCipher, createDecipher } = require('./transforms/encryption')
 
 const closeTimeout = 30 * 1000
 
@@ -181,11 +181,11 @@ class Client extends EventEmitter {
 
   setEncryption (sharedSecret) {
     if (this.cipher != null) { this.emit('error', new Error('Set encryption twice!')) }
-    this.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.cipher = createCipher(sharedSecret)
     this.cipher.on('error', (err) => this.emit('error', err))
     this.framer.unpipe(this.socket)
     this.framer.pipe(this.cipher).pipe(this.socket)
-    this.decipher = crypto.createDecipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.decipher = createDecipher(sharedSecret)
     this.decipher.on('error', (err) => this.emit('error', err))
     this.socket.unpipe(this.splitter)
     this.socket.pipe(this.decipher).pipe(this.splitter)

--- a/src/transforms/encryption-fallback-test.js
+++ b/src/transforms/encryption-fallback-test.js
@@ -1,0 +1,91 @@
+const encryption = require('./encryption');
+
+/*
+
+Test for crypto-js fallback
+Change between fallback and nodejs crypto by editing the expression in encryption.js to true or false
+
+########### Nodejs crypto
+
+input     TextToEncryptAndThenDecrypt 27
+encrypted 608e4df02a82de4a03c547e8f8ac3f924a6e962a43e9242ad5eaa5 27
+decrypted TextToEncryptAndThenDecrypt 27
+
+input     ThisIsTheSecondMessageForTheSameStream 38
+encrypted 3379188d66a141f184b5175991fe8c7cfe7b20c7a4b7eb9382f4b645d0cbf5df4f84e298a880 38
+decrypted ThisIsTheSecondMessageForTheSameStream 38
+
+
+########### crypto-js
+
+input     TextToEncryptAndThenDecrypt 27
+encrypted 608e4df02a82de4a03c547e8f8ac3f924a6e962a43e9242ad5eaa5 27
+decrypted TextToEncryptAndThenDecrypt 27
+
+input     ThisIsTheSecondMessageForTheSameStream 38
+encrypted 3379188d66a141f184b5175991fe8c7cfe7b20c7a4b7eb9382f4b645d0cbf5df4f84e298a880 38
+decrypted ThisIsTheSecondMessageForTheSameStream 38
+
+*/
+
+//--- Setup
+
+var key = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+const cipher = encryption.createCipher(key);
+console.log("Cipher Init")
+const decipher = encryption.createDecipher(key);
+console.log("Decipher Init")
+
+let decrypted = Buffer.alloc(0);
+let encrypted = Buffer.alloc(0);
+
+decipher.on('readable', () => {
+    let chunk;
+    while (true) {
+        chunk = decipher.read()
+        if (chunk == null) break;
+        decrypted = Buffer.concat([decrypted, chunk]);
+        //console.log(chunk)
+    }
+    console.log("decrypted", decrypted.toString('utf8'), decrypted.length);
+    decrypted = Buffer.alloc(0);
+});
+decipher.on('end', () => {
+    console.log("Decipher End")
+});
+
+cipher.on('readable', () => {
+    let chunk;
+    while (true) {
+        chunk = cipher.read()
+        if (chunk == null) break;
+        //console.log(chunk)
+        encrypted = Buffer.concat([encrypted, chunk]);
+        decipher.write(chunk)
+    }
+    console.log("encrypted", encrypted.toString('hex'), encrypted.length);
+    encrypted = Buffer.alloc(0);
+});
+cipher.on('end', () => {
+    console.log("Cipher End")
+});
+
+//--- Start
+
+const text = ['TextToEncryptAndThenDecrypt', "ThisIsTheSecondMessageForTheSameStream"];
+const dlay = 500;
+
+for (let i = 0; i < text.length; i++) {
+    setTimeout(() => {
+        console.log("")
+        console.log("input    ", text[i], text[i].length)
+        cipher.write(Buffer.from(text[i]));
+    }, dlay * i)
+}
+
+setTimeout(() => {
+    console.log("")
+    cipher.end();
+    decipher.end();
+}, dlay * (text.length + 1));

--- a/src/transforms/encryption.js
+++ b/src/transforms/encryption.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const crypto = require('crypto')
+
+if (crypto.getCiphers().indexOf('aes-128-cfb8') !== -1) {
+    // Native supported
+    module.exports.createCipher = function(secret) {
+        return crypto.createCipheriv('aes-128-cfb8', secret, secret)
+    }
+
+    module.exports.createDecipher = function(secret) {
+        return crypto.createDecipheriv('aes-128-cfb8', secret, secret)
+    }
+
+} else {
+    // Fallback
+    const { Transform } = require('stream');
+
+    const CryptoJS = require("crypto-js/core");
+    require("crypto-js/x64-core");
+    require("crypto-js/cipher-core");
+
+    require("crypto-js/enc-hex")
+    require("crypto-js/pad-nopadding");
+
+    require("crypto-js/aes");
+    //require("crypto-js/mode-cfb");
+    CryptoJS.mode.CFBb = require("cryptojs-extension/build_node/mode-cfb-b");
+
+    console.log("Using crypto-js fallback")
+
+    class Cipher extends Transform {
+        constructor(secret) {
+            super();
+            this.key = secret;
+            this.iv = this.key;
+        }
+
+        // Conversion functions taken from https://gist.github.com/artjomb/7ef1ee574a411ba0dd1933c1ef4690d1
+        /*byteArrayToWordArray(ba) { //Should be used later, currently just using hex to convert stuff
+            var wa = [],
+                i;
+            for (i = 0; i < ba.length; i++) {
+                wa[(i / 4) | 0] |= ba[i] << (24 - 8 * i);
+            }
+            return CryptoJS.lib.WordArray.create(wa, ba.length);
+        }*/
+
+        wordToByteArray(word, length) {
+            var ba = [],
+                i,
+                xFF = 0xFF;
+            if (length > 0)
+                ba.push(word >>> 24);
+            if (length > 1)
+                ba.push((word >>> 16) & xFF);
+            if (length > 2)
+                ba.push((word >>> 8) & xFF);
+            if (length > 3)
+                ba.push(word & xFF);
+
+            return ba;
+        }
+
+        wordArrayToByteArray(wordArray, length) {
+            if (wordArray.hasOwnProperty("sigBytes") && wordArray.hasOwnProperty("words")) {
+                length = wordArray.sigBytes;
+                wordArray = wordArray.words;
+            }
+
+            var result = [],
+                bytes,
+                i = 0;
+            while (length > 0) {
+                bytes = this.wordToByteArray(wordArray[i], Math.min(4, length));
+                length -= bytes.length;
+                result.push(bytes);
+                i++;
+            }
+            return [].concat.apply([], result);
+        }
+
+
+        _transform(chunk, enc, cb) {
+            try {
+                //console.log("enc:" + enc);
+                //console.log("c-in", chunk)
+
+                let encrypted = CryptoJS.AES.encrypt(
+                    CryptoJS.enc.Hex.parse(chunk.toString('hex')),
+                    CryptoJS.enc.Hex.parse(this.key.toString('hex')), {
+                        iv: CryptoJS.enc.Hex.parse(this.iv.toString('hex')),
+                        mode: CryptoJS.mode.CFBb,
+                        segmentSize: 8,
+                        padding: CryptoJS.pad.NoPadding
+                    }
+                )
+
+                //console.log("ct:", encrypted.ciphertext)
+                let cout = Buffer.from(this.wordArrayToByteArray(encrypted.ciphertext));
+                //console.log("c-out", cout)
+                this.iv = cout.slice(cout.length - 16, cout.length);
+
+                cb(null, cout);
+            } catch (e) {
+                cb(e); //This can cause "Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times" when an error was thrown while calling cb in the try block.
+            }
+        }
+    }
+
+    class Decipher extends Cipher {
+        _transform(chunk, enc, cb) {
+            try {
+                //console.log("enc:" + enc);
+                //console.log("dc-in", chunk)
+
+                let inp = CryptoJS.enc.Hex.parse(chunk.toString('hex')); //hex and binary
+                //console.log("dc-in2", inp);
+
+                let decrypted = CryptoJS.AES.decrypt( //
+                    { ciphertext: inp },
+                    CryptoJS.enc.Hex.parse(this.key.toString('hex')), //
+                    {
+                        iv: CryptoJS.enc.Hex.parse(this.iv.toString('hex')),
+                        mode: CryptoJS.mode.CFBb,
+                        segmentSize: 8,
+                        padding: CryptoJS.pad.NoPadding
+                    }
+                );
+
+                let resbuf = Buffer.from(this.wordArrayToByteArray(decrypted));
+                //console.log("dc-out", resbuf)
+                this.iv = chunk.slice(chunk.length - 16, chunk.length);
+
+                cb(null, resbuf);
+            } catch (e) {
+                cb(e);
+            }
+        }
+    }
+
+    module.exports.createCipher = function(secret) {
+        return new Cipher(secret)
+    }
+
+    module.exports.createDecipher = function(secret) {
+        return new Decipher(secret)
+    }
+}


### PR DESCRIPTION
This PR proposes a fallback to the native nodejs crypto module.
This is usefull because some environments like electron/chromium have disabled the default module(OpenSSL) in favor of boringSSL.

While inspired by #735, I tried to implement a solution with crypto-js and cryptojs-extension because I  could not reproduce the same behaviour with aes-js.

The current code does not work and should probably be changed a lot. I have included a file named encryption-fallback-test.js that i used to test my solution. To use this file just change the first expression in encryption.js to true or false and see if the output changes.

I dont know what the current issue is but this still does not work with mineflayer. 
I also do not have the knowledge on how to debug this so any help would be apprechiated.

Minecraft v1.16.1
Electron v9.1.2
Mineflayer v2.25.0

#748 and #743 are also related.
