### PR TITLE
Implement fallback aes-js support for cfb8

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
+    "aes-js": "^3.1.2",
     "yggdrasil": "^1.3.0",
     "buffer-equal": "^1.0.0",
     "debug": "^4.1.0",

--- a/src/client.js
+++ b/src/client.js
@@ -4,11 +4,12 @@ const EventEmitter = require('events').EventEmitter
 const debug = require('debug')('minecraft-protocol')
 const compression = require('./transforms/compression')
 const framing = require('./transforms/framing')
-const crypto = require('crypto')
 const states = require('./states')
 
 const createSerializer = require('./transforms/serializer').createSerializer
 const createDeserializer = require('./transforms/serializer').createDeserializer
+const createCipher = require('./transforms/encryption').createCipher
+const createDecipher = require('./transforms/encryption').createDecipher
 
 const closeTimeout = 30 * 1000
 
@@ -181,11 +182,11 @@ class Client extends EventEmitter {
 
   setEncryption (sharedSecret) {
     if (this.cipher != null) { this.emit('error', new Error('Set encryption twice!')) }
-    this.cipher = crypto.createCipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.cipher = createCipher(sharedSecret)
     this.cipher.on('error', (err) => this.emit('error', err))
     this.framer.unpipe(this.socket)
     this.framer.pipe(this.cipher).pipe(this.socket)
-    this.decipher = crypto.createDecipheriv('aes-128-cfb8', sharedSecret, sharedSecret)
+    this.decipher = createDecipher(sharedSecret)
     this.decipher.on('error', (err) => this.emit('error', err))
     this.socket.unpipe(this.splitter)
     this.socket.pipe(this.decipher).pipe(this.splitter)

--- a/src/transforms/encryption.js
+++ b/src/transforms/encryption.js
@@ -1,0 +1,54 @@
+const Transform = require('readable-stream').Transform
+const crypto = require('crypto')
+const aesjs = require('aes-js')
+
+function createCipher (secret) {
+  if (crypto.getCiphers().includes('aes-128-cfb8')) {
+    return crypto.createCipheriv('aes-128-cfb8', secret, secret)
+  }
+  return new Cipher(secret)
+}
+
+function createDecipher (secret) {
+  if (crypto.getCiphers().includes('aes-128-cfb8')) {
+    return crypto.createDecipheriv('aes-128-cfb8', secret, secret)
+  }
+  return new Decipher(secret)
+}
+
+class Cipher extends Transform {
+  constructor (secret) {
+    super()
+    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line
+  }
+
+  _transform (chunk, enc, cb) {
+    try {
+      const res = this.aes.encrypt(chunk)
+      cb(null, res)
+    } catch (e) {
+      cb(e)
+    }
+  }
+}
+
+class Decipher extends Transform {
+  constructor (secret) {
+    super()
+    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line
+  }
+
+  _transform (chunk, enc, cb) {
+    try {
+      const res = this.aes.decrypt(chunk)
+      cb(null, res)
+    } catch (e) {
+      cb(e)
+    }
+  }
+}
+
+module.exports = {
+  createCipher: createCipher,
+  createDecipher: createDecipher
+}

--- a/src/transforms/encryption.js
+++ b/src/transforms/encryption.js
@@ -19,7 +19,7 @@ function createDecipher (secret) {
 class Cipher extends Transform {
   constructor (secret) {
     super()
-    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line
+    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line new-cap
   }
 
   _transform (chunk, enc, cb) {
@@ -35,7 +35,7 @@ class Cipher extends Transform {
 class Decipher extends Transform {
   constructor (secret) {
     super()
-    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line
+    this.aes = new aesjs.ModeOfOperation.cfb(secret, secret, 1) // eslint-disable-line new-cap
   }
 
   _transform (chunk, enc, cb) {


### PR DESCRIPTION
Tested with a flying squid online mode server, works fine.
The 2 lines with disable eslint are due to standard complaining about aes-js's naming convention for classes, which we cannot change.