### PR TITLE
Fixes crashes

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -84,7 +84,7 @@ class Client extends EventEmitter {
       parsed.metadata.state = state
       debug('read packet ' + state + '.' + parsed.metadata.name)
       const s = JSON.stringify(parsed.data, null, 2)
-      debug(s.length > 10000 ? parsed.data : s)
+      debug(s && s.length > 10000 ? parsed.data : s)
       this.emit('packet', parsed.data, parsed.metadata)
       this.emit(parsed.metadata.name, parsed.data, parsed.metadata)
       this.emit('raw.' + parsed.metadata.name, parsed.buffer, parsed.metadata)


### PR DESCRIPTION
Sometimes parsed.data is undefined, meaning the `s` variable is evaluated to undefined. When trying to read the length of the variable, it causes `Cannot read property 'length' of undefined`. By checking that `s` is defined before checking it's length prevents the crash from happening.