### PR TITLE
Server Brand

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -21,7 +21,8 @@ function createServer (options = {}) {
     maxPlayers: maxPlayersNew = 20,
     version,
     favicon,
-    customPackets
+    customPackets,
+    serverBrand = 'node-minecraft-protocol'
   } = options
 
   const maxPlayers = options['max-players'] !== undefined ? maxPlayersOld : maxPlayersNew
@@ -41,6 +42,7 @@ function createServer (options = {}) {
   server.onlineModeExceptions = {}
   server.favicon = favicon
   server.serverKey = new NodeRSA({ b: 1024 })
+  server.serverBrand = serverBrand
 
   server.on('connection', function (client) {
     plugins.forEach(plugin => plugin(client, server, options))

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,11 @@ declare module 'minecraft-protocol' {
 		on(event: 'state', handler: (newState: States, oldState: States) => void): this
 		on(event: 'end', handler: (reason: string) => void): this
 		on(event: string, handler: (data: any, packetMeta: PacketMeta)=> unknown): this
+		/**
+		 * Send a brand plugin message, if there is no parameter the `server.serverBrand` property will be used
+		 * works only for server side clients `client.isServer === true`
+		 */
+		sendBrand(brand?: string): void
 	}
 
 	export interface ClientOptions {
@@ -80,6 +85,7 @@ declare module 'minecraft-protocol' {
 		beforePing?: (response: any, client: Client, callback?: (result: any) => any) => any
 		errorHandler?: (client: Client, error: Error) => void
 		agent?: Agent
+		serverBrand?: string
 	}
 
 	export interface SerializerOptions {

--- a/src/server/brand.js
+++ b/src/server/brand.js
@@ -1,11 +1,11 @@
 const PLAY = require('../states').PLAY
 module.exports = (client, server) => {
-    client.sendBrand = (brand = server.serverBrand) => {
-        if (client.state !== PLAY) throw new Error(`The state of the client must be PLAY (actual state: ${client.state})`)
-        client.writeChannel((
-            client.protocolVersion >= 385 // (385 = 1.13-pre3) as of 1.13 (The Flattening), the name of the default channels has changed
-                ? 'brand'
-                : 'MC|Brand'
-        ), brand)
-    }
+  client.sendBrand = (brand = server.serverBrand) => {
+    if (client.state !== PLAY) throw new Error(`The state of the client must be PLAY (actual state: ${client.state})`)
+    client.writeChannel((
+      client.protocolVersion >= 385 // (385 = 1.13-pre3) as of 1.13 (The Flattening), the name of the default channels has changed
+        ? 'brand'
+        : 'MC|Brand'
+    ), brand)
+  }
 }

--- a/src/server/brand.js
+++ b/src/server/brand.js
@@ -1,0 +1,11 @@
+const PLAY = require('../states').PLAY
+module.exports = (client, server) => {
+    client.sendBrand = (brand = server.serverBrand) => {
+        if (client.state !== PLAY) throw new Error(`The state of the client must be PLAY (actual state: ${client.state})`)
+        client.writeChannel((
+            client.protocolVersion >= 385 // (385 = 1.13-pre3) as of 1.13 (The Flattening), the name of the default channels has changed
+                ? 'brand'
+                : 'MC|Brand'
+        ), brand)
+    }
+}

--- a/src/server/login.js
+++ b/src/server/login.js
@@ -124,6 +124,11 @@ module.exports = function (client, server, options) {
       server.playerCount -= 1
     })
     pluginChannels(client, options)
+    client.registerChannel((
+      client.protocolVersion >= 385 // (385 = 1.13-pre3) as of 1.13 (The Flattening), the name of the default channels has changed
+      ? 'brand'
+      : 'MC|Brand'
+    ), ['string', []])
     server.emit('login', client)
   }
 }

--- a/src/server/login.js
+++ b/src/server/login.js
@@ -126,8 +126,8 @@ module.exports = function (client, server, options) {
     pluginChannels(client, options)
     client.registerChannel((
       client.protocolVersion >= 385 // (385 = 1.13-pre3) as of 1.13 (The Flattening), the name of the default channels has changed
-      ? 'brand'
-      : 'MC|Brand'
+        ? 'brand'
+        : 'MC|Brand'
     ), ['string', []])
     server.emit('login', client)
   }

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -7,7 +7,7 @@ module.exports = function (client, server, { beforePing = null }) {
   function onPing () {
     const response = {
       version: {
-        name: server.mcversion.minecraftVersion,
+        name: `${server.serverBrand} ${server.mcversion.minecraftVersion}`,
         protocol: server.mcversion.version
       },
       players: {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -170,7 +170,7 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
           delete results.latency
           assert.deepEqual(results, {
             version: {
-              name: version.minecraftVersion,
+              name: 'node-minecraft-protocol' + version.minecraftVersion,
               protocol: version.version
             },
             players: {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -170,7 +170,7 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
           delete results.latency
           assert.deepEqual(results, {
             version: {
-              name: 'node-minecraft-protocol' + version.minecraftVersion,
+              name: 'node-minecraft-protocol ' + version.minecraftVersion,
               protocol: version.version
             },
             players: {


### PR DESCRIPTION
Added a new function, `Client#sendBrand(string)`, this function will send the brand plugin message. It only works for server side clients `client.isServer === true`.
Added a new optional parameter to `createServer(options)` called `serverBrand` which is used as default value for `sendBrand()` if no parameter is given and in the ping response, the default value is `node-minecraft-protocol`.