### PR TITLE
Allow immediate shutdown of the client script once not in use

### DIFF
--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -9,6 +9,8 @@ module.exports = function (client, options) {
   client.on('keep_alive', onKeepAlive)
 
   let timeout = null
+  
+  client.on('end', () => clearTimeout(timeout));
 
   function onKeepAlive (packet) {
     if (timeout) { clearTimeout(timeout) }

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -10,7 +10,7 @@ module.exports = function (client, options) {
 
   let timeout = null
   
-  client.on('end', () => clearTimeout(timeout));
+  client.on('end', () => clearTimeout(timeout))
 
   function onKeepAlive (packet) {
     if (timeout) { clearTimeout(timeout) }

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -9,7 +9,7 @@ module.exports = function (client, options) {
   client.on('keep_alive', onKeepAlive)
 
   let timeout = null
-  
+
   client.on('end', () => clearTimeout(timeout))
 
   function onKeepAlive (packet) {


### PR DESCRIPTION
If the client connection was terminated by anything else than the Keep Alive Timeout the script would hang until that timeout had finished. Clearing the interval fixes that problem.