### PR TITLE
[CI] update to actions/setup-java@v1.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: 1.8
         java-package: jre


### PR DESCRIPTION
CI seems to be failing because of this recent change https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

see also the CI results on #780 where I first noticed this