### PR TITLE
Don't stringify every packet if debug not enabled

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -83,8 +83,10 @@ class Client extends EventEmitter {
       parsed.data = parsed.data.params
       parsed.metadata.state = state
       debug('read packet ' + state + '.' + parsed.metadata.name)
-      const s = JSON.stringify(parsed.data, null, 2)
-      debug(s && s.length > 10000 ? parsed.data : s)
+      if (debug.enabled) {
+        const s = JSON.stringify(parsed.data, null, 2)
+        debug(s && s.length > 10000 ? parsed.data : s)
+      }
       this.emit('packet', parsed.data, parsed.metadata, parsed.buffer)
       this.emit(parsed.metadata.name, parsed.data, parsed.metadata)
       this.emit('raw.' + parsed.metadata.name, parsed.buffer, parsed.metadata)


### PR DESCRIPTION
The JSON.stringify call here takes up a huge amount of CPU time, especially toward the beginning of a bot's lifetime when the server is sending a lot of data.

There might be other places where expensive debug messages are prepared without debug necessarily enabled, I didn't check, but this one is especially costly.