### PR TITLE
Add support for lazy packet parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node-fetch": "^2.6.1",
     "node-rsa": "^0.4.2",
     "prismarine-nbt": "^1.3.0",
-    "protodef": "^1.8.0",
+    "protodef": "evan-goode/node-protodef#lazy",
     "readable-stream": "^3.0.6",
     "uuid-1345": "^1.0.1",
     "yggdrasil": "^1.4.0"

--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -2,7 +2,7 @@
 
 const ProtoDef = require('protodef').ProtoDef
 const Serializer = require('protodef').Serializer
-const Parser = require('protodef').FullPacketParser
+const Parser = require('protodef').LazyPacketParser
 const { ProtoDefCompiler } = require('protodef').Compiler
 
 const minecraft = require('../datatypes/minecraft')
@@ -38,7 +38,7 @@ function createSerializer ({ state = states.HANDSHAKING, isServer = false, versi
 }
 
 function createDeserializer ({ state = states.HANDSHAKING, isServer = false, version, customPackets, compiled = true, noErrorLogging = false } = {}) {
-  return new Parser(createProtocol(state, isServer ? 'toServer' : 'toClient', version, customPackets, compiled), 'packet', noErrorLogging)
+  return new Parser(createProtocol(state, isServer ? 'toServer' : 'toClient', version, customPackets, compiled), 'packet', 'packet_shallow', noErrorLogging)
 }
 
 module.exports = {


### PR DESCRIPTION
Dynamically create a "packet_shallow" type for use with the lazy parser at https://github.com/ProtoDef-io/node-protodef/pull/114. 

See https://github.com/PrismarineJS/node-minecraft-protocol/issues/779