### PR TITLE
Msa device code auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 test/npm-debug.log
-test/server
+test/server*
 package-lock.json
 versions/
 src/client/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/npm-debug.log
 test/server
 package-lock.json
 versions/
+src/client/*.json

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,11 +74,16 @@ Returns a `Client` instance and perform login.
 `options` is an object containing the properties :
  * username
  * port : default to 25565
- * password : can be omitted (if the tokens and profilesFolder are also omitted then it tries to connect in offline mode)
+ * auth : the type of account to use, either `microsoft` or `mojang`. default to 'mojang'
+ * password : can be omitted
+   * (microsoft account) leave this blank to use device code auth. If you provide
+   a password, we try to do username and password auth, but this does not always work.
+   * (mojang account) If provided, we auth with the username and password. If this
+   is blank, and `profilesFolder` is specified, we auth with the tokens there instead.
+   If neither `password` or `profilesFolder` are specified, we connect in offline mode.
  * host : default to localhost
  * clientToken : generated if a password is given
  * accessToken : generated if a password or microsoft account is given
- * auth : the type of auth server to use, either 'microsoft' or 'mojang'. default to 'mojang'
  * authServer : auth server, default to https://authserver.mojang.com
  * sessionServer : session server, default to https://sessionserver.mojang.com
  * keepAlive : send keep alive packets : default to true
@@ -93,7 +98,12 @@ Returns a `Client` instance and perform login.
  * connect : a function taking the client as parameter and that should client.setSocket(socket) 
  and client.emit('connect') when appropriate (see the proxy examples for an example of use)
  * agent : a http agent that can be used to set proxy settings for yggdrasil authentication (see proxy-agent on npm) 
- * profilesFolder : the path to the folder that contains your `launcher_profiles.json`. defaults to your minecraft folder if it exists, otherwise the local directory. set to `false` to disable managing profiles
+ * profilesFolder : optional
+   * (mojang account) the path to the folder that contains your `launcher_profiles.json`. defaults to your minecraft folder if it exists, otherwise the local directory. set to `false` to disable managing profiles 
+   * (microsoft account) the path to store authentication caches, defaults to .minecraft
+ * onMsaCode(data) : (optional) callback called when signing in with a microsoft account
+ with device code auth. `data` is an object documented [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#device-authorization-response)
+
 
 ## mc.Client(isServer,version,[customPackets])
 

--- a/examples/client_electron/main.js
+++ b/examples/client_electron/main.js
@@ -28,7 +28,7 @@ function main () {
     client.on('error', (err) => {
       dialog.showMessageBoxSync({
         type: 'error',
-        message: err.message + '\n' + err.stack
+        message: err.stack
       })
     })
 

--- a/examples/client_electron/main.js
+++ b/examples/client_electron/main.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const { app, ipcMain } = require('electron')
+const { app, ipcMain, dialog } = require('electron')
 const mc = require('minecraft-protocol')
 
 const Window = require('./Window')
@@ -17,8 +17,21 @@ function main () {
   })
 
   ipcMain.on('connect', (e, data) => {
+    data.onMsaCode = (data) => {
+      dialog.showMessageBoxSync({
+        type: 'info',
+        message: 'Please authenticate now:\n' + data.message
+      })
+    }
     const client = mc.createClient(data)
     client.on('login', () => mainWindow.send('content', 'connected'))
+    client.on('error', (err) => {
+      dialog.showMessageBoxSync({
+        type: 'error',
+        message: err.message + '\n' + err.stack
+      })
+    })
+
     let chat = ''
 
     client.on('chat', function (packet) {

--- a/examples/client_electron/renderer/index.html
+++ b/examples/client_electron/renderer/index.html
@@ -8,10 +8,13 @@
 
   <body>
 
-    Host: <input type="text" id="host" value="localhost" /><br />
-    Port: <input type="text" id="port" value="25565"/><br />
-    Username: <input type="text" id="username" value="electron_client" /><br />
-    Password: <input type="text" id="password" value="" /><br />
+    <div>
+      <p>Host: <input type="text" id="host" value="localhost" /></p>
+      <p>Port: <input type="text" id="port" value="25565"/></p>
+      <p>Account Type: <select onchange="onAuthTypeChange()" id='type'><option>Microsoft</option><option>Mojang</option></select></p>
+      <p>Username: <input type="text" id="username" value="electron_client" /></p>
+      <p>Password: <input type="text" id="password" value="" /></p>
+    </div>
 
     <button id="connect" type="button">Connect</button><br />
     <div id="content">Not connected</div> <br />

--- a/examples/client_electron/renderer/index.js
+++ b/examples/client_electron/renderer/index.js
@@ -10,11 +10,17 @@ function setContent (content) {
 
 document.getElementById('connect').addEventListener('click', () => {
   setContent('connecting...')
+  const authType = document.getElementById('type')
+
   const data = {
     host: document.getElementById('host').value,
     port: parseInt(document.getElementById('port').value),
     username: document.getElementById('username').value,
     password: document.getElementById('password').value === '' ? undefined : document.getElementById('password').value
+  }
+  if (authType.value === 'Microsoft') {
+    data.auth = 'microsoft'
+    delete data.password
   }
   ipcRenderer.send('connect', data)
 })
@@ -32,6 +38,11 @@ document.getElementById('chat').addEventListener('keyup', function onEvent (e) {
 document.getElementById('send').addEventListener('click', () => {
   chat()
 })
+
+window.onAuthTypeChange = function () {
+  const authType = document.getElementById('type')
+  console.log('set auth type to', authType)
+}
 
 ipcRenderer.on('content', (event, content) => {
   setContent(content)

--- a/examples/client_microsoft_auth/client_msal_auth.js
+++ b/examples/client_microsoft_auth/client_msal_auth.js
@@ -11,7 +11,7 @@ const client = mc.createClient({
   host: process.argv[2],
   port: parseInt(process.argv[3]),
   username: process.argv[4], // your microsoft account email
-//   password: process.argv[5], // your microsoft account password
+  //   password: process.argv[5], // your microsoft account password
   auth: 'microsoft' // This option must be present and set to 'microsoft' to use Microsoft Account Authentication. Failure to do so will result in yggdrasil throwing invalid account information.
 })
 

--- a/examples/client_microsoft_auth/client_msal_auth.js
+++ b/examples/client_microsoft_auth/client_msal_auth.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const mc = require('minecraft-protocol')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node echo.js <host> <port> <email>')
+  process.exit(1)
+}
+
+const client = mc.createClient({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4], // your microsoft account email
+//   password: process.argv[5], // your microsoft account password
+  auth: 'microsoft' // This option must be present and set to 'microsoft' to use Microsoft Account Authentication. Failure to do so will result in yggdrasil throwing invalid account information.
+})
+
+client.on('connect', function () {
+  console.info('connected')
+})
+client.on('disconnect', function (packet) {
+  console.log('disconnected: ' + packet.reason)
+})
+client.on('chat', function (packet) {
+  const jsonMsg = JSON.parse(packet.message)
+  if (jsonMsg.translate === 'chat.type.announcement' || jsonMsg.translate === 'chat.type.text') {
+    const username = jsonMsg.with[0].text
+    const msg = jsonMsg.with[1]
+    if (username === client.username) return
+    client.write('chat', { message: msg })
+  }
+})

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "standard": "^16.0.1"
   },
   "dependencies": {
+    "@azure/msal-node": "^1.0.0-beta.3",
     "@xboxreplay/xboxlive-auth": "^3.3.0",
     "aes-js": "^3.1.2",
     "buffer-equal": "^1.0.0",

--- a/src/client/authConstants.js
+++ b/src/client/authConstants.js
@@ -1,0 +1,11 @@
+const XSTSRelyingParty = 'rp://api.minecraftservices.com/'
+const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
+const MinecraftServicesEntitlement = 'https://api.minecraftservices.com/entitlements/mcstore'
+const MinecraftServicesProfile = 'https://api.minecraftservices.com/minecraft/profile'
+
+module.exports = {
+  XSTSRelyingParty,
+  MinecraftServicesLogWithXbox,
+  MinecraftServicesEntitlement,
+  MinecraftServicesProfile
+}

--- a/src/client/authConstants.js
+++ b/src/client/authConstants.js
@@ -1,11 +1,6 @@
-const XSTSRelyingParty = 'rp://api.minecraftservices.com/'
-const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
-const MinecraftServicesEntitlement = 'https://api.minecraftservices.com/entitlements/mcstore'
-const MinecraftServicesProfile = 'https://api.minecraftservices.com/minecraft/profile'
-
 module.exports = {
-  XSTSRelyingParty,
-  MinecraftServicesLogWithXbox,
-  MinecraftServicesEntitlement,
-  MinecraftServicesProfile
+  XSTSRelyingParty: 'rp://api.minecraftservices.com/',
+  MinecraftServicesLogWithXbox: 'https://api.minecraftservices.com/authentication/login_with_xbox',
+  MinecraftServicesEntitlement: 'https://api.minecraftservices.com/entitlements/mcstore',
+  MinecraftServicesProfile: 'https://api.minecraftservices.com/minecraft/profile'
 }

--- a/src/client/authFlow.js
+++ b/src/client/authFlow.js
@@ -1,0 +1,130 @@
+const crypto = require('crypto')
+const path = require('path')
+const fs = require('fs')
+const debug = require('debug')('minecraft-protocol')
+const mcDefaultFolderPath = require('minecraft-folder-path')
+const authConstants = require('./authConstants')
+const { MsaTokenManager, XboxTokenManager, MinecraftTokenManager } = require('./tokens')
+
+// Initialize msal
+// Docs: https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-common/docs/request.md#public-apis-1
+const msalConfig = {
+  auth: {
+    // the minecraft client:
+    // clientId: "000000004C12AE6F",
+    clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
+    authority: 'https://login.microsoftonline.com/consumers'
+  }
+}
+
+async function retry (methodFn, beforeRety, times) {
+  while (times--) {
+    if (times !== 0) {
+      try { return await methodFn() } catch (e) { debug(e) }
+      await beforeRety()
+    } else {
+      return await methodFn()
+    }
+  }
+}
+
+class MsAuthFlow {
+  constructor (username, cacheDir, codeCallback) {
+    this.initTokenCaches(username, cacheDir)
+    this.codeCallback = codeCallback
+  }
+
+  initTokenCaches (username, cacheDir) {
+    const hash = sha1(username).substr(0, 6)
+
+    let cachePath = cacheDir || mcDefaultFolderPath
+    try {
+      if (!fs.existsSync(cachePath + '/nmp-cache')) {
+        fs.mkdirSync(cachePath + '/nmp-cache')
+      }
+      cachePath += '/nmp-cache'
+    } catch (e) {
+      console.log('Failed to open cache dir', e)
+      cachePath = __dirname
+    }
+
+    const cachePaths = {
+      msa: path.join(cachePath, `./${hash}_msa-cache.json`),
+      xbl: path.join(cachePath, `./${hash}_xbl-cache.json`),
+      mca: path.join(cachePath, `./${hash}_mca-cache.json`)
+    }
+
+    const scopes = ['XboxLive.signin', 'offline_access']
+    this.msa = new MsaTokenManager(msalConfig, scopes, cachePaths.msa)
+    this.xbl = new XboxTokenManager(authConstants.XSTSRelyingParty, cachePaths.xbl)
+    this.mca = new MinecraftTokenManager(cachePaths.mca)
+  }
+
+  static resetTokenCaches (cacheDir) {
+    let cachePath = cacheDir || mcDefaultFolderPath
+    try {
+      if (fs.existsSync(cachePath + '/nmp-cache')) {
+        cachePath += '/nmp-cache'
+        fs.rmdirSync(cachePath, { recursive: true })
+        return true
+      }
+    } catch (e) {
+      console.log('Failed to clear cache dir', e)
+      return false
+    }
+  }
+
+  async getMsaToken () {
+    if (await this.msa.verifyTokens()) {
+      debug('[msa] Using existing tokens')
+      return this.msa.getAccessToken().token
+    } else {
+      debug('[msa] No valid cached tokens, need to sign in')
+      const ret = await this.msa.authDeviceCode((response) => {
+        console.info('[msa] First time signing in. Please authenticate now:')
+        console.info(response.message)
+        if (this.codeCallback) this.codeCallback(response)
+      })
+
+      console.info(`[msa] Signed in as ${ret.account.username}`)
+
+      debug('[msa] got auth result', ret)
+      return ret.accessToken
+    }
+  }
+
+  async getXboxToken () {
+    if (await this.xbl.verifyTokens()) {
+      debug('[xbl] Using existing tokens')
+      return this.xbl.getCachedXstsToken().data
+    } else {
+      debug('[xbl] Need to obtain tokens')
+      return await retry(async () => {
+        const msaToken = await this.getMsaToken()
+        const ut = await this.xbl.getUserToken(msaToken)
+        const xsts = await this.xbl.getXSTSToken(ut)
+        return xsts
+      }, () => { this.msa.forceRefresh = true }, 1)
+    }
+  }
+
+  async getMinecraftToken () {
+    if (await this.mca.verifyTokens()) {
+      debug('[mc] Using existing tokens')
+      return this.mca.getCachedAccessToken().token
+    } else {
+      debug('[mc] Need to obtain tokens')
+      return await retry(async () => {
+        const xsts = await this.getXboxToken()
+        debug('[xbl] xsts data', xsts)
+        return this.mca.getAccessToken(xsts)
+      }, () => { this.xbl.forceRefresh = true }, 1)
+    }
+  }
+}
+
+function sha1 (data) {
+  return crypto.createHash('sha1').update(data || '', 'binary').digest('hex')
+}
+
+module.exports = { MsAuthFlow }

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -58,7 +58,7 @@ async function postAuthenticate (client, options, mcAccessToken) {
     } else {
       const user = msa.getUsers()[0]
       // debug(user)
-      console.error(`Failed to obtain Minecraft profile data for '${user.username}', does the account own Minecraft Java?`)
+      console.error(`Failed to obtain Minecraft profile data for '${user?.username}', does the account own Minecraft Java?`)
       throw Error(res.statusText)
     }
   })

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -164,14 +164,17 @@ async function postAuthenticate (client, options, mcAccessToken, msa) {
   let minecraftProfile
   const res = await fetch(authConstants.MinecraftServicesProfile, getFetchOptions)
   if (res.ok) { // res.status >= 200 && res.status < 300
-    minecraftProfile = res.json()
+    minecraftProfile = await res.json()
   } else {
     const user = msa ? msa.getUsers()[0] : options.username
     // debug(user)
     throw Error(`Failed to obtain Minecraft profile data for '${user?.username}', does the account own Minecraft Java? Server returned: ${res.statusText}`)
   }
 
-  if (!minecraftProfile.id) throw Error('This user does not own minecraft according to minecraft services.')
+  if (!minecraftProfile.id) {
+    console.debug('[mc] profile', minecraftProfile)
+    throw Error('This user does not own minecraft according to minecraft services.')
+  }
 
   // This profile / session here could be simplified down to where it just passes the uuid of the player to encrypt.js
   // That way you could remove some lines of code. It accesses client.session.selectedProfile.id so /shrug.

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -54,52 +54,9 @@ let relayParty = 'rp://api.minecraftservices.com/'
 let xbl = new XboxTokenManager({ relayParty })
 let mca = new MinecraftTokenManager()
 
-// async function authenticateMsa() {
-//   if (await msa.verifyTokens()) { // We have valid tokens
-//     console.debug('[msa] re-using existing tokens')
-//     return msa.getAccessToken()
-//   }
-
-//   let ret = await msa.authDeviceToken((response) => {
-//     console.info('[msa] First time signing in. Please authenticate now:')
-//     console.info(response.message)
-//     // console.log('Data', data)
-//   })
-
-//   console.info(`[msa] Signed in as ${ret.account.username}`)
-
-//   console.log(ret)
-//   return ret.accessToken
-// }
-
 function debug(...message) {
   console.debug(message[0])
 }
-
-// async function authenticateXbl(msaAccessToken) {
-//   debug('[xbl] obtaining xbox token with ms token', msaAccessToken)
-
-//   if (await xbl.verifyTokens()) {
-//     debug('[xbl] re-using existing xbox tokens')
-//     return xbl.getCachedXstsToken().data
-//   }
-
-//   let ut = await xbl.getUserToken(msaAccessToken)
-//   let xt = await xbl.getXSTSToken(ut)
-
-//   console.log(xt)
-//   return xt
-// }
-
-// async function authenticateMinecraft(xsts) {
-//   if (await mca.verifyTokens()) {
-//     debug('[msa] re-using existing xbox tokens')
-//     return mca.getCachedAccessToken().token
-//   }
-//   let mctoken = await mca.getAccessToken(xsts)
-//   debug('Minecraft token: ', mctoken)
-//   return mctoken
-// }
 
 async function postAuthenticate(client, options, mcAccessToken) {
   options.haveCredentials = mcAccessToken != null
@@ -221,13 +178,6 @@ module.exports = {
   authenticatePassword,
   authenticateDeviceToken
 }
-
-// async function msaTest() {
-//   let msaToken = await authenticateMsa()
-//   let xblToken = await authenticateXbl(msaToken.token)
-//   let mcToken = await authenticateMinecraft(xblToken)
-//   // let tm = new TokenManager('389b1b32-b5d5-43b2-bddc-84ce938d6737')
-// }
 
 async function msaTest() {
   await authenticateDeviceToken({}, {})

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -1,10 +1,7 @@
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
+const msal = require('@azure/msal-node')
 const fetch = require('node-fetch')
-
-const XSTSRelyingParty = 'rp://api.minecraftservices.com/'
-const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
-const MinecraftServicesEntitlement = 'https://api.minecraftservices.com/entitlements/mcstore'
-const MinecraftServicesProfile = 'https://api.minecraftservices.com/minecraft/profile'
+const { MsaTokenManager, XboxTokenManager, MinecraftTokenManager } = require('./tokens')
 
 const getFetchOptions = {
   headers: {
@@ -13,14 +10,141 @@ const getFetchOptions = {
   }
 }
 
+const XSTSRelyingParty = 'rp://api.minecraftservices.com/'
+const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
+const MinecraftServicesEntitlement = 'https://api.minecraftservices.com/entitlements/mcstore'
+const MinecraftServicesProfile = 'https://api.minecraftservices.com/minecraft/profile'
+
+// Initialize msal
+
+// See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-common/docs/request.md#public-apis-1
+// for docs
+const msalConfig = {
+  auth: {
+    // the minecraft client:
+    // clientId: "000000004C12AE6F",
+    // clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
+    clientId: '60bad957-e36a-472d-a72a-612ad7f66b46', // @extremeheat
+    // clientId: '1fec8e78-bce4-4aaf-ab1b-5451cc387264', // MS Teams
+    authority: "https://login.microsoftonline.com/consumers"
+    // test out using live.com:
+    // validateAuthority: false,
+    // knownAuthorities: ["login.live.com"],
+    // protocolMode: 'OIDC',
+
+    // authority: 'https://login.live.com'
+  },
+  // cache: {
+  //   cachePlugin // your implementation of cache plugin
+  // },
+  system: {
+    loggerOptions: {
+      loggerCallback(loglevel, message, containsPii) {
+        // console.log('[msal] ', this.logLevel, message);
+      },
+      piiLoggingEnabled: false,
+      logLevel: msal.LogLevel.Verbose,
+    }
+  }
+}
+
+let scopes = ['XboxLive.signin', 'offline_access']
+let msa = new MsaTokenManager({ msalConfig, scopes })
+let relayParty = 'rp://api.minecraftservices.com/'
+let xbl = new XboxTokenManager({ relayParty })
+let mca = new MinecraftTokenManager()
+
+// async function authenticateMsa() {
+//   if (await msa.verifyTokens()) { // We have valid tokens
+//     console.debug('[msa] re-using existing tokens')
+//     return msa.getAccessToken()
+//   }
+
+//   let ret = await msa.authDeviceToken((response) => {
+//     console.info('[msa] First time signing in. Please authenticate now:')
+//     console.info(response.message)
+//     // console.log('Data', data)
+//   })
+
+//   console.info(`[msa] Signed in as ${ret.account.username}`)
+
+//   console.log(ret)
+//   return ret.accessToken
+// }
+
+function debug(...message) {
+  console.debug(message[0])
+}
+
+// async function authenticateXbl(msaAccessToken) {
+//   debug('[xbl] obtaining xbox token with ms token', msaAccessToken)
+
+//   if (await xbl.verifyTokens()) {
+//     debug('[xbl] re-using existing xbox tokens')
+//     return xbl.getCachedXstsToken().data
+//   }
+
+//   let ut = await xbl.getUserToken(msaAccessToken)
+//   let xt = await xbl.getXSTSToken(ut)
+
+//   console.log(xt)
+//   return xt
+// }
+
+// async function authenticateMinecraft(xsts) {
+//   if (await mca.verifyTokens()) {
+//     debug('[msa] re-using existing xbox tokens')
+//     return mca.getCachedAccessToken().token
+//   }
+//   let mctoken = await mca.getAccessToken(xsts)
+//   debug('Minecraft token: ', mctoken)
+//   return mctoken
+// }
+
+async function postAuthenticate(client, options, mcAccessToken) {
+  options.haveCredentials = mcAccessToken != null
+
+  const MinecraftProfile = await fetch(MinecraftServicesProfile, getFetchOptions).then((res) => {
+    if (res.ok) { // res.status >= 200 && res.status < 300
+      return res.json()
+    } else {
+      let user = msa.getUsers()[0]
+      debug(user)
+      console.error(`Failed to obtain Minecraft profile data for '${ user.username }', does the account own Minecraft Java?`)
+      throw Error(res.statusText)
+    }
+  })
+  if (!MinecraftProfile.id) throw Error('This user does not own minecraft according to minecraft services.')
+
+  // This profile / session here could be simplified down to where it just passes the uuid of the player to encrypt.js
+  // That way you could remove some lines of code. It accesses client.session.selectedProfile.id so /shrug.
+  // - Kashalls
+  const profile = {
+    name: MinecraftProfile.name,
+    id: MinecraftProfile.id
+  }
+
+  const session = {
+    accessToken: mcAccessToken,
+    selectedProfile: profile,
+    availableProfile: [profile]
+  }
+  client.session = session
+  client.username = MinecraftProfile.name
+  options.accessToken = MineServicesResponse.access_token
+  client.emit('session', session)
+  options.connect(client)
+}
+
 /**
- * Authenticates with Xbox Live, then Authenticates with Minecraft, Checks Entitlements and Gets Profile.
+ * Authenticates with Mincrosoft through user credentials, then
+ * with Xbox Live, Minecraft, checks entitlements and returns profile
+ * 
  * @function
  * @param {object} client - The client passed to protocol
  * @param {object} options - Client Options
  */
-
-module.exports = async (client, options) => {
+async function authenticatePassword(client, options) {
   // Use external library to authenticate with
   const XAuthResponse = await XboxLiveAuth.authenticate(options.username, options.password, { XSTSRelyingParty })
     .catch((err) => {
@@ -34,39 +158,82 @@ module.exports = async (client, options) => {
     body: JSON.stringify({ identityToken: `XBL3.0 x=${XAuthResponse.userHash};${XAuthResponse.XSTSToken}` })
   }).then(checkStatus)
 
-  options.haveCredentials = MineServicesResponse.access_token != null
-
   getFetchOptions.headers.Authorization = `Bearer ${MineServicesResponse.access_token}`
   const MineEntitlements = await fetch(MinecraftServicesEntitlement, getFetchOptions).then(checkStatus)
   if (MineEntitlements.items.length === 0) throw Error('This user does not have any items on its accounts according to minecraft services.')
 
-  const MinecraftProfile = await fetch(MinecraftServicesProfile, getFetchOptions).then(checkStatus)
-  if (!MinecraftProfile.id) throw Error('This user does not own minecraft according to minecraft services.')
-
-  // This profile / session here could be simplified down to where it just passes the uuid of the player to encrypt.js
-  // That way you could remove some lines of code. It accesses client.session.selectedProfile.id so /shrug.
-  // - Kashalls
-  const profile = {
-    name: MinecraftProfile.name,
-    id: MinecraftProfile.id
-  }
-
-  const session = {
-    accessToken: MineServicesResponse.access_token,
-    selectedProfile: profile,
-    availableProfile: [profile]
-  }
-  client.session = session
-  client.username = MinecraftProfile.name
-  options.accessToken = MineServicesResponse.access_token
-  client.emit('session', session)
-  options.connect(client)
+  postAuthenticate(client, options, MineServicesResponse.access_token)
 }
 
-function checkStatus (res) {
+async function getMsaToken() {
+  if (await msa.verifyTokens()) {
+    return msa.getAccessToken().token
+  } else {
+    let ret = await msa.authDeviceToken((response) => {
+      console.info('[msa] First time signing in. Please authenticate now:')
+      console.info(response.message)
+      // console.log('Data', data)
+    })
+  
+    console.info(`[msa] Signed in as ${ret.account.username}`)
+  
+    debug(ret)
+    return ret.accessToken
+  }
+}
+
+async function getXboxToken() {
+  if (await xbl.verifyTokens()) {
+    return xbl.getCachedXstsToken().data
+  } else {
+    let msaToken = await getMsaToken()
+    let ut = await xbl.getUserToken(msaToken)
+    let xsts = await xbl.getXSTSToken(ut)
+    return xsts.data
+  }
+}
+
+async function getMinecraftToken() {
+  if (await mca.verifyTokens()) {
+    return mca.getCachedAccessToken().token
+  } else {
+    let xsts = await getXboxToken()
+    return mca.getAccessToken(xsts)
+  }
+}
+
+async function authenticateDeviceToken(client, options) {
+  let token = await getMinecraftToken()
+  console.debug('Aquired Minecraft token', token)
+
+  postAuthenticate(client, options, token)
+}
+
+function checkStatus(res) {
   if (res.ok) { // res.status >= 200 && res.status < 300
     return res.json()
   } else {
     throw Error(res.statusText)
   }
+}
+
+module.exports = {
+  authenticatePassword,
+  authenticateDeviceToken
+}
+
+// async function msaTest() {
+//   let msaToken = await authenticateMsa()
+//   let xblToken = await authenticateXbl(msaToken.token)
+//   let mcToken = await authenticateMinecraft(xblToken)
+//   // let tm = new TokenManager('389b1b32-b5d5-43b2-bddc-84ce938d6737')
+// }
+
+async function msaTest() {
+  await authenticateDeviceToken({}, {})
+}
+
+// debug with node microsoftAuth.js
+if (!module.parent) {
+  msaTest()
 }

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -175,8 +175,8 @@ async function initTokenCaches (username, cacheDir) {
 
   let cachePath = cacheDir || mcDefaultFolderPath
   try {
-    await fs.promises.access(cachePath)
-    fs.mkdirSync(cachePath + '/nmp-cache')
+    if (!fs.existsSync(cachePath + '/nmp-cache'))
+      fs.mkdirSync(cachePath + '/nmp-cache')
     cachePath += '/nmp-cache'
   } catch (e) {
     console.log('Failed to open cache dir', e)

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -3,6 +3,7 @@ const msal = require('@azure/msal-node')
 const fetch = require('node-fetch')
 const authConstants = require('./authConstants')
 const crypto = require('crypto')
+const path = require('path')
 const { MsaTokenManager, XboxTokenManager, MinecraftTokenManager } = require('./tokens')
 
 const getFetchOptions = {
@@ -78,7 +79,7 @@ async function postAuthenticate (client, options, mcAccessToken) {
   }
   client.session = session
   client.username = MinecraftProfile.name
-  options.accessToken = authConstants.MineServicesResponse.access_token
+  options.accessToken = MineServicesResponse.access_token
   client.emit('session', session)
   options.connect(client)
 }
@@ -159,9 +160,9 @@ async function initTokenCaches (username) {
   const hash = sha1(username).substr(0, 6)
 
   const cachePaths = {
-    msa: `./${hash}_msa-cache.json`,
-    xbl: `./${hash}_xbl-cache.json`,
-    mca: `./${hash}_mca-cache.json`
+    msa: path.join(__dirname, `./${hash}_msa-cache.json`),
+    xbl: path.join(__dirname, `./${hash}_xbl-cache.json`),
+    mca: path.join(__dirname, `./${hash}_mca-cache.json`)
   }
 
   const scopes = ['XboxLive.signin', 'offline_access']

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -175,8 +175,9 @@ async function initTokenCaches (username, cacheDir) {
 
   let cachePath = cacheDir || mcDefaultFolderPath
   try {
-    if (!fs.existsSync(cachePath + '/nmp-cache'))
+    if (!fs.existsSync(cachePath + '/nmp-cache')) {
       fs.mkdirSync(cachePath + '/nmp-cache')
+    }
     cachePath += '/nmp-cache'
   } catch (e) {
     console.log('Failed to open cache dir', e)

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -79,7 +79,7 @@ async function postAuthenticate (client, options, mcAccessToken) {
   }
   client.session = session
   client.username = MinecraftProfile.name
-  options.accessToken = MineServicesResponse.access_token
+  options.accessToken = mcAccessToken
   client.emit('session', session)
   options.connect(client)
 }

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -21,8 +21,8 @@ const msalConfig = {
   auth: {
     // the minecraft client:
     // clientId: "000000004C12AE6F",
-    // clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
-    clientId: '60bad957-e36a-472d-a72a-612ad7f66b46', // @extremeheat
+    clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
+    // clientId: '60bad957-e36a-472d-a72a-612ad7f66b46', // @extremeheat
     // clientId: '1fec8e78-bce4-4aaf-ab1b-5451cc387264', // MS Teams
     authority: 'https://login.microsoftonline.com/consumers'
 

--- a/src/client/microsoftAuth.js
+++ b/src/client/microsoftAuth.js
@@ -1,13 +1,8 @@
-const msal = require('@azure/msal-node')
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
-// const debug = require('debug')('minecraft-protocol')
+const debug = require('debug')('minecraft-protocol')
 const fetch = require('node-fetch')
-const crypto = require('crypto')
-const path = require('path')
-const fs = require('fs')
-const mcDefaultFolderPath = require('minecraft-folder-path')
 const authConstants = require('./authConstants')
-const { MsaTokenManager, XboxTokenManager, MinecraftTokenManager } = require('./tokens')
+const { MsAuthFlow } = require('./authFlow.js')
 
 const getFetchOptions = {
   headers: {
@@ -16,148 +11,13 @@ const getFetchOptions = {
   }
 }
 
-// Initialize msal
-
-// See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-common/docs/request.md#public-apis-1
-// for docs
-const msalConfig = {
-  auth: {
-    // the minecraft client:
-    // clientId: "000000004C12AE6F",
-    clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
-    // clientId: '60bad957-e36a-472d-a72a-612ad7f66b46', // @extremeheat
-    // clientId: '1fec8e78-bce4-4aaf-ab1b-5451cc387264', // MS Teams
-    authority: 'https://login.microsoftonline.com/consumers'
-
-    // test out using live.com:
-    // validateAuthority: false,
-    // knownAuthorities: ["login.live.com"],
-    // protocolMode: 'OIDC',
-    // authority: 'https://login.live.com'
-  },
-  system: {
-    loggerOptions: {
-      loggerCallback (loglevel, message, containsPii) {
-        // console.debug('[msal] ', this.logLevel, message)
-      },
-      piiLoggingEnabled: false,
-      logLevel: msal.LogLevel.Verbose
-    }
-  }
-}
-
-function debug (...message) {
-  console.debug(message[0])
-}
-
-async function retry (methodFn, beforeRety, times) {
-  while (times--) {
-    if (times !== 0) {
-      try { return await methodFn() } catch (e) { debug(e) }
-      await beforeRety()
-    } else {
-      return await methodFn()
-    }
-  }
-}
-
-// TODO: Move this to a new file
-class MsAuthFlow {
-  constructor (username, cacheDir, codeCallback) {
-    this.initTokenCaches(username, cacheDir)
-    this.codeCallback = codeCallback
-  }
-
-  initTokenCaches (username, cacheDir) {
-    const hash = sha1(username).substr(0, 6)
-
-    let cachePath = cacheDir || mcDefaultFolderPath
-    try {
-      if (!fs.existsSync(cachePath + '/nmp-cache')) {
-        fs.mkdirSync(cachePath + '/nmp-cache')
-      }
-      cachePath += '/nmp-cache'
-    } catch (e) {
-      console.log('Failed to open cache dir', e)
-      cachePath = __dirname
-    }
-
-    const cachePaths = {
-      msa: path.join(cachePath, `./${hash}_msa-cache.json`),
-      xbl: path.join(cachePath, `./${hash}_xbl-cache.json`),
-      mca: path.join(cachePath, `./${hash}_mca-cache.json`)
-    }
-
-    const scopes = ['XboxLive.signin', 'offline_access']
-    this.msa = new MsaTokenManager(msalConfig, scopes, cachePaths.msa)
-    this.xbl = new XboxTokenManager(authConstants.XSTSRelyingParty, cachePaths.xbl)
-    this.mca = new MinecraftTokenManager(cachePaths.mca)
-  }
-
-  static resetTokenCaches (cacheDir) {
-    let cachePath = cacheDir || mcDefaultFolderPath
-    try {
-      if (fs.existsSync(cachePath + '/nmp-cache')) {
-        cachePath += '/nmp-cache'
-        fs.rmdirSync(cachePath, { recursive: true })
-        return true
-      }
-    } catch (e) {
-      console.log('Failed to clear cache dir', e)
-      return false
-    }
-  }
-
-  async getMsaToken () {
-    if (await this.msa.verifyTokens()) {
-      debug('[msa] Using existing tokens')
-      return this.msa.getAccessToken().token
-    } else {
-      debug('[msa] Not using existing, need to sign in')
-      const ret = await this.msa.authDeviceCode((response) => {
-        console.info('[msa] First time signing in. Please authenticate now:')
-        console.info(response.message)
-        // console.log('Data', data)
-        if (this.codeCallback) this.codeCallback(response)
-      })
-
-      console.info(`[msa] Signed in as ${ret.account.username}`)
-
-      debug('[msa] got auth result', ret)
-      return ret.accessToken
-    }
-  }
-
-  async getXboxToken () {
-    if (await this.xbl.verifyTokens()) {
-      debug('[xbl] Using existing tokens')
-      return this.xbl.getCachedXstsToken().data
-    } else {
-      debug('[xbl] Need to obtain tokens')
-      return await retry(async () => {
-        const msaToken = await this.getMsaToken()
-        const ut = await this.xbl.getUserToken(msaToken)
-        const xsts = await this.xbl.getXSTSToken(ut)
-        return xsts
-      }, () => { this.msa.forceRefresh = true }, 1)
-    }
-  }
-
-  async getMinecraftToken () {
-    if (await this.mca.verifyTokens()) {
-      debug('[mc] Using existing tokens')
-      return this.mca.getCachedAccessToken().token
-    } else {
-      debug('[mc] Need to obtain tokens')
-      return await retry(async () => {
-        const xsts = await this.getXboxToken()
-        debug('[xbl] xsts data', xsts)
-        return this.mca.getAccessToken(xsts)
-      }, () => { this.xbl.forceRefresh = true }, 1)
-    }
-  }
-}
-
+/**
+ * Obtains Minecaft profile data using a Minecraft access token and starts the join sequence
+ * @param {object} client - The client passed to protocol
+ * @param {object} options - Client Options
+ * @param {string} mcAccessToken - Minecraft access token for session server
+ * @param {object?} msa - Cached Microsoft account data for more descriptive errors
+ */
 async function postAuthenticate (client, options, mcAccessToken, msa) {
   options.haveCredentials = mcAccessToken != null
 
@@ -167,12 +27,11 @@ async function postAuthenticate (client, options, mcAccessToken, msa) {
     minecraftProfile = await res.json()
   } else {
     const user = msa ? msa.getUsers()[0] : options.username
-    // debug(user)
     throw Error(`Failed to obtain Minecraft profile data for '${user?.username}', does the account own Minecraft Java? Server returned: ${res.statusText}`)
   }
 
   if (!minecraftProfile.id) {
-    console.debug('[mc] profile', minecraftProfile)
+    debug('[mc] profile', minecraftProfile)
     throw Error('This user does not own minecraft according to minecraft services.')
   }
 
@@ -249,7 +108,7 @@ async function authenticateDeviceCode (client, options) {
     const flow = new MsAuthFlow(options.username, options.profilesFolder, options.onMsaCode)
 
     const token = await flow.getMinecraftToken()
-    console.debug('Acquired Minecraft token', token)
+    debug('Acquired Minecraft token', token.slice(0, 16))
 
     getFetchOptions.headers.Authorization = `Bearer ${token}`
     await postAuthenticate(client, options, token, flow.msa)
@@ -265,10 +124,6 @@ function checkStatus (res) {
   } else {
     throw Error(res.statusText)
   }
-}
-
-function sha1 (data) {
-  return crypto.createHash('sha1').update(data || '', 'binary').digest('hex')
 }
 
 module.exports = {

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -4,25 +4,24 @@ const path = require('path')
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const fetch = require('node-fetch')
 
-function debug(...message) {
+function debug (...message) {
   console.debug(message[0])
 }
 
 // Manages Microsoft account tokens
 class MsaTokenManager {
-  constructor({ msalConfig, scopes, cacheLocation }) {
+  constructor ({ msalConfig, scopes, cacheLocation }) {
     this.msaClientId = msalConfig.auth.clientId
     this.scopes = scopes
+    this.cacheLocation = cacheLocation || path.join(__dirname, './msa-cache.json')
 
-    if (!cacheLocation) cacheLocation = path.join(__dirname, './msa-cache.json')
-
-    let beforeCacheAccess = async (cacheContext) => {
-      cacheContext.tokenCache.deserialize(await fs.promises.readFile(cacheLocation, "utf-8"))
+    const beforeCacheAccess = async (cacheContext) => {
+      cacheContext.tokenCache.deserialize(await fs.promises.readFile(this.cacheLocation, 'utf-8'))
     }
 
-    let afterCacheAccess = async (cacheContext) => {
+    const afterCacheAccess = async (cacheContext) => {
       if (cacheContext.cacheHasChanged) {
-        await fs.promises.writeFile(cacheLocation, cacheContext.tokenCache.serialize())
+        await fs.promises.writeFile(this.cacheLocation, cacheContext.tokenCache.serialize())
       }
     }
 
@@ -38,39 +37,40 @@ class MsaTokenManager {
     this.msalConfig = msalConfig
 
     try {
-      this.msaCache = require(cacheLocation)
+      this.msaCache = require(this.cacheLocation)
     } catch (e) {
       this.msaCache = {}
+      fs.writeFileSync(this.cacheLocation, JSON.stringify(this.msaCache))
     }
   }
 
-  getUsers() {
-    let accounts = this.msaCache.Account
-    let users = []
-    for (var account of Object.values(accounts)) {
+  getUsers () {
+    const accounts = this.msaCache.Account
+    const users = []
+    for (const account of Object.values(accounts)) {
       users.push(account)
     }
     return users
   }
 
-  getAccessToken() {
-    let tokens = this.msaCache.AccessToken
+  getAccessToken () {
+    const tokens = this.msaCache.AccessToken
     if (!tokens) return
-    let account = Object.values(tokens).filter(t => t.client_id == this.msaClientId)[0]
+    const account = Object.values(tokens).filter(t => t.client_id === this.msaClientId)[0]
     if (!account) {
       debug('[msa] No valid access token found', tokens)
       return
     }
     // console.log(account)
-    let until = (Date.now() - new Date(account.expires_on * 1000))
-    let valid = until < 1000
+    const until = (Date.now() - new Date(account.expires_on * 1000))
+    const valid = until < 1000
     return { valid, until: until * -1, token: account.secret }
   }
 
-  getRefreshToken() {
-    let tokens = this.msaCache.RefreshToken
+  getRefreshToken () {
+    const tokens = this.msaCache.RefreshToken
     if (!tokens) return
-    let account = Object.values(tokens).filter(t => t.client_id == this.msaClientId)[0]
+    const account = Object.values(tokens).filter(t => t.client_id === this.msaClientId)[0]
     if (!account) {
       debug('[msa] No valid refresh token found', tokens)
       return
@@ -78,30 +78,30 @@ class MsaTokenManager {
     return { token: account.secret }
   }
 
-  async refreshTokens() {
-    let rtoken = this.getRefreshToken()
+  async refreshTokens () {
+    const rtoken = this.getRefreshToken()
     if (!rtoken) {
-      throw 'Cannot refresh without refresh token'
+      throw new Error('Cannot refresh without refresh token')
     }
     const refreshTokenRequest = {
       refreshToken: rtoken.token,
-      scopes: this.scopes,
+      scopes: this.scopes
     }
 
-    return new Promise((res, rej) => {
+    return new Promise((resolve, reject) => {
       this.msalApp.acquireTokenByRefreshToken(refreshTokenRequest).then((response) => {
         debug('[msa] refreshed token', JSON.stringify(response))
-        res(response)
+        resolve(response)
       }).catch((error) => {
         debug('[msa] failed to refresh', JSON.stringify(error))
-        rej(error)
+        reject(error)
       })
     })
   }
 
-  async verifyTokens() {
-    let at = this.getAccessToken()
-    let rt = this.getRefreshToken()
+  async verifyTokens () {
+    const at = this.getAccessToken()
+    const rt = this.getRefreshToken()
     if (!at || !rt) {
       return false
     }
@@ -116,11 +116,10 @@ class MsaTokenManager {
         return false
       }
     }
-    return false
   }
 
   // Authenticate with device_code flow
-  async authDeviceToken(dataCallback) {
+  async authDeviceToken (dataCallback) {
     const deviceCodeRequest = {
       deviceCodeCallback: (resp) => {
         debug('[msa] device_code response: ', resp)
@@ -129,66 +128,64 @@ class MsaTokenManager {
       scopes: this.scopes
     }
 
-    return new Promise((res, rej) => {
+    return new Promise((resolve, reject) => {
       this.msalApp.acquireTokenByDeviceCode(deviceCodeRequest).then((response) => {
-        debug('[msa] device_code resp', JSON.stringify(response));
-        res(response)
+        debug('[msa] device_code resp', JSON.stringify(response))
+        resolve(response)
       }).catch((error) => {
         console.warn('ERROR!', error)
-        console.log('ERROR!', JSON.stringify(error));
-        rej(error)
+        console.log('ERROR!', JSON.stringify(error))
+        reject(error)
       })
     })
   }
 }
 
-
 // Manages Xbox Live tokens for xboxlive.com
 class XboxTokenManager {
-  constructor({ relayParty, cacheLocation }) {
+  constructor ({ relayParty, cacheLocation }) {
     this.relayParty = relayParty
-    if (!cacheLocation) cacheLocation = path.join(__dirname, './xbl-cache.json')
+    this.cacheLocation = cacheLocation || path.join(__dirname, './xbl-cache.json')
     try {
-      this.cache = require(cacheLocation)
+      this.cache = require(this.cacheLocation)
     } catch (e) {
       this.cache = {}
     }
-    this.cacheLocation = cacheLocation
   }
 
-  getCachedUserToken() {
-    let token = this.cache.userToken
+  getCachedUserToken () {
+    const token = this.cache.userToken
     if (!token) return
-    let until = new Date(token.NotAfter)
-    let dn = Date.now()
-    let remainingMs = until - dn
-    let valid = remainingMs > 1000
+    const until = new Date(token.NotAfter)
+    const dn = Date.now()
+    const remainingMs = until - dn
+    const valid = remainingMs > 1000
     return { valid, token: token.Token, data: token }
   }
 
-  getCachedXstsToken() {
-    let token = this.cache.xstsToken
+  getCachedXstsToken () {
+    const token = this.cache.xstsToken
     if (!token) return
-    let until = new Date(token.expiresOn)
-    let dn = Date.now()
-    let remainingMs = until - dn
-    let valid = remainingMs > 1000
-    return { valid, token: token.Token, data: token }
+    const until = new Date(token.expiresOn)
+    const dn = Date.now()
+    const remainingMs = until - dn
+    const valid = remainingMs > 1000
+    return { valid, token: token.XSTSToken, data: token }
   }
 
-  setCachedUserToken(data) {
+  setCachedUserToken (data) {
     this.cache.userToken = data
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
   }
 
-  setCachedXstsToken(data) {
+  setCachedXstsToken (data) {
     this.cache.xstsToken = data
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
   }
 
-  async verifyTokens() {
-    let ut = this.getCachedUserToken()
-    let xt = this.getCachedXstsToken()
+  async verifyTokens () {
+    const ut = this.getCachedUserToken()
+    const xt = this.getCachedXstsToken()
     if (!ut || !xt) {
       return false
     }
@@ -205,19 +202,18 @@ class XboxTokenManager {
     return false
   }
 
-  async getUserToken(msaAccessToken) {
+  async getUserToken (msaAccessToken) {
     debug('[xbl] obtaining xbox token with ms token', msaAccessToken)
-    if (!msaAccessToken.startsWith('d='))
-      msaAccessToken = 'd=' + msaAccessToken // took way too long to figure this out
-    let xblUserToken = await XboxLiveAuth.exchangeRpsTicketForUserToken(msaAccessToken)
+    if (!msaAccessToken.startsWith('d=')) { msaAccessToken = 'd=' + msaAccessToken }
+    const xblUserToken = await XboxLiveAuth.exchangeRpsTicketForUserToken(msaAccessToken)
     this.setCachedUserToken(xblUserToken)
     debug('[xbl] user token:', xblUserToken)
     return xblUserToken
   }
 
-  async getXSTSToken(xblUserToken) {
+  async getXSTSToken (xblUserToken) {
     debug('[xbl] obtaining xsts token with xbox user token', xblUserToken.Token)
-    let xsts = await XboxLiveAuth.exchangeUserTokenForXSTSIdentity(
+    const xsts = await XboxLiveAuth.exchangeUserTokenForXSTSIdentity(
       xblUserToken.Token, { XSTSRelyingParty: this.relayParty, raw: false }
     )
     this.setCachedXstsToken(xsts)
@@ -226,37 +222,36 @@ class XboxTokenManager {
   }
 }
 
-// Manages Minecraft tokens for sessionserver.mojang.com 
+// Manages Minecraft tokens for sessionserver.mojang.com
 class MinecraftTokenManager {
-  constructor({ cacheLocation } = {}) {
-    if (!cacheLocation) cacheLocation = path.join(__dirname, './mca-cache.json')
+  constructor ({ cacheLocation } = {}) {
+    this.cacheLocation = cacheLocation || path.join(__dirname, './mca-cache.json')
     try {
-      this.cache = require(cacheLocation)
+      this.cache = require(this.cacheLocation)
     } catch (e) {
       this.cache = {}
     }
-    this.cacheLocation = cacheLocation
   }
 
-  getCachedAccessToken() {
-    let token = this.cache.mca
+  getCachedAccessToken () {
+    const token = this.cache.mca
     // console.log('MC token cache', this.cache)
     if (!token) return
-    let expires = token.obtainedOn + (token.expires_in * 1000)
-    let remaining = expires - Date.now()
-    let valid = remaining > 1000
+    const expires = token.obtainedOn + (token.expires_in * 1000)
+    const remaining = expires - Date.now()
+    const valid = remaining > 1000
     return { valid, until: expires, token: token.access_token, data: token }
   }
 
-  setCachedAccessToken(data) {
+  setCachedAccessToken (data) {
     data.obtainedOn = Date.now()
     this.cache.mca = data
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
     // console.log('cached', data, this.cache, this.cacheLocation)
   }
 
-  async verifyTokens() {
-    let at = this.getCachedAccessToken()
+  async verifyTokens () {
+    const at = this.getCachedAccessToken()
     if (!at) {
       return false
     }
@@ -267,7 +262,7 @@ class MinecraftTokenManager {
     return false
   }
 
-  async getAccessToken(xsts) {
+  async getAccessToken (xsts) {
     debug('[mc] authing to minecraft', xsts)
     const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
     const getFetchOptions = {
@@ -281,30 +276,30 @@ class MinecraftTokenManager {
       ...getFetchOptions,
       body: JSON.stringify({ identityToken: `XBL3.0 x=${xsts.userHash};${xsts.XSTSToken}` })
     }).then(checkStatus)
-  
+
     debug('[mc] mc auth response', MineServicesResponse)
     this.setCachedAccessToken(MineServicesResponse)
     return MineServicesResponse.access_token
   }
 
-  async verifyEntitlements() {
+  async verifyEntitlements () {
     // TODO
   }
 }
 
-if (typeof btoa === 'undefined') {
-  global.btoa = function (str) {
-    return new Buffer(str, 'binary').toString('base64');
-  };
-}
+// if (typeof btoa === 'undefined') {
+//   global.btoa = function (str) {
+//     return new Buffer(str, 'binary').toString('base64')
+//   }
+// }
 
-if (typeof atob === 'undefined') {
-  global.atob = function (b64Encoded) {
-    return new Buffer(b64Encoded, 'base64').toString('binary');
-  };
-}
+// if (typeof atob === 'undefined') {
+//   global.atob = function (b64Encoded) {
+//     return new Buffer(b64Encoded, 'base64').toString('binary')
+//   }
+// }
 
-function checkStatus(res) {
+function checkStatus (res) {
   if (res.ok) { // res.status >= 200 && res.status < 300
     return res.json()
   } else {

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -16,6 +16,13 @@ class MsaTokenManager {
     this.scopes = scopes
     this.cacheLocation = cacheLocation || path.join(__dirname, './msa-cache.json')
 
+    try {
+      this.msaCache = require(this.cacheLocation)
+    } catch (e) {
+      this.msaCache = {}
+      fs.writeFileSync(this.cacheLocation, JSON.stringify(this.msaCache))
+    }
+
     const beforeCacheAccess = async (cacheContext) => {
       cacheContext.tokenCache.deserialize(await fs.promises.readFile(this.cacheLocation, 'utf-8'))
     }
@@ -36,18 +43,12 @@ class MsaTokenManager {
     }
     this.msalApp = new msal.PublicClientApplication(msalConfig)
     this.msalConfig = msalConfig
-
-    try {
-      this.msaCache = require(this.cacheLocation)
-    } catch (e) {
-      this.msaCache = {}
-      fs.writeFileSync(this.cacheLocation, JSON.stringify(this.msaCache))
-    }
   }
 
   getUsers () {
     const accounts = this.msaCache.Account
     const users = []
+    if (!accounts) return users
     for (const account of Object.values(accounts)) {
       users.push(account)
     }

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const fetch = require('node-fetch')
+const authConstants = require('./authConstants')
 
 function debug (...message) {
   console.debug(message[0])
@@ -264,14 +265,13 @@ class MinecraftTokenManager {
 
   async getAccessToken (xsts) {
     debug('[mc] authing to minecraft', xsts)
-    const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
     const getFetchOptions = {
       headers: {
         'Content-Type': 'application/json',
         'User-Agent': 'node-minecraft-protocol'
       }
     }
-    const MineServicesResponse = await fetch(MinecraftServicesLogWithXbox, {
+    const MineServicesResponse = await fetch(authConstants.MinecraftServicesLogWithXbox, {
       method: 'post',
       ...getFetchOptions,
       body: JSON.stringify({ identityToken: `XBL3.0 x=${xsts.userHash};${xsts.XSTSToken}` })

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -1,0 +1,315 @@
+const msal = require('@azure/msal-node')
+const fs = require('fs')
+const path = require('path')
+const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
+const fetch = require('node-fetch')
+
+function debug(...message) {
+  console.debug(message[0])
+}
+
+// Manages Microsoft account tokens
+class MsaTokenManager {
+  constructor({ msalConfig, scopes, cacheLocation }) {
+    this.msaClientId = msalConfig.auth.clientId
+    this.scopes = scopes
+
+    if (!cacheLocation) cacheLocation = path.join(__dirname, './msa-cache.json')
+
+    let beforeCacheAccess = async (cacheContext) => {
+      cacheContext.tokenCache.deserialize(await fs.promises.readFile(cacheLocation, "utf-8"))
+    }
+
+    let afterCacheAccess = async (cacheContext) => {
+      if (cacheContext.cacheHasChanged) {
+        await fs.promises.writeFile(cacheLocation, cacheContext.tokenCache.serialize())
+      }
+    }
+
+    const cachePlugin = {
+      beforeCacheAccess,
+      afterCacheAccess
+    }
+
+    msalConfig.cache = {
+      cachePlugin
+    }
+    this.msalApp = new msal.PublicClientApplication(msalConfig)
+    this.msalConfig = msalConfig
+
+    try {
+      this.msaCache = require(cacheLocation)
+    } catch (e) {
+      this.msaCache = {}
+    }
+  }
+
+  getUsers() {
+    let accounts = this.msaCache.Account
+    let users = []
+    for (var account of Object.values(accounts)) {
+      users.push(account)
+    }
+    return users
+  }
+
+  getAccessToken() {
+    let tokens = this.msaCache.AccessToken
+    if (!tokens) return
+    let account = Object.values(tokens).filter(t => t.client_id == this.msaClientId)[0]
+    if (!account) {
+      debug('[msa] No valid access token found', tokens)
+      return
+    }
+    // console.log(account)
+    let until = (Date.now() - new Date(account.expires_on * 1000))
+    let valid = until < 1000
+    return { valid, until: until * -1, token: account.secret }
+  }
+
+  getRefreshToken() {
+    let tokens = this.msaCache.RefreshToken
+    if (!tokens) return
+    let account = Object.values(tokens).filter(t => t.client_id == this.msaClientId)[0]
+    if (!account) {
+      debug('[msa] No valid refresh token found', tokens)
+      return
+    }
+    return { token: account.secret }
+  }
+
+  async refreshTokens() {
+    let rtoken = this.getRefreshToken()
+    if (!rtoken) {
+      throw 'Cannot refresh without refresh token'
+    }
+    const refreshTokenRequest = {
+      refreshToken: rtoken.token,
+      scopes: this.scopes,
+    }
+
+    return new Promise((res, rej) => {
+      this.msalApp.acquireTokenByRefreshToken(refreshTokenRequest).then((response) => {
+        debug('[msa] refreshed token', JSON.stringify(response))
+        res(response)
+      }).catch((error) => {
+        debug('[msa] failed to refresh', JSON.stringify(error))
+        rej(error)
+      })
+    })
+  }
+
+  async verifyTokens() {
+    let at = this.getAccessToken()
+    let rt = this.getRefreshToken()
+    if (!at || !rt) {
+      return false
+    }
+    debug('[msa] have at, rt', at, rt)
+    if (at.valid && rt) {
+      return true
+    } else {
+      try {
+        this.refreshTokens()
+        return true
+      } catch (e) {
+        return false
+      }
+    }
+    return false
+  }
+
+  // Authenticate with device_code flow
+  async authDeviceToken(dataCallback) {
+    const deviceCodeRequest = {
+      deviceCodeCallback: (resp) => {
+        debug('[msa] device_code response: ', resp)
+        dataCallback(resp)
+      },
+      scopes: this.scopes
+    }
+
+    return new Promise((res, rej) => {
+      this.msalApp.acquireTokenByDeviceCode(deviceCodeRequest).then((response) => {
+        debug('[msa] device_code resp', JSON.stringify(response));
+        res(response)
+      }).catch((error) => {
+        console.warn('ERROR!', error)
+        console.log('ERROR!', JSON.stringify(error));
+        rej(error)
+      })
+    })
+  }
+}
+
+
+// Manages Xbox Live tokens for xboxlive.com
+class XboxTokenManager {
+  constructor({ relayParty, cacheLocation }) {
+    this.relayParty = relayParty
+    if (!cacheLocation) cacheLocation = path.join(__dirname, './xbl-cache.json')
+    try {
+      this.cache = require(cacheLocation)
+    } catch (e) {
+      this.cache = {}
+    }
+    this.cacheLocation = cacheLocation
+  }
+
+  getCachedUserToken() {
+    let token = this.cache.userToken
+    if (!token) return
+    let until = new Date(token.NotAfter)
+    let dn = Date.now()
+    let remainingMs = until - dn
+    let valid = remainingMs > 1000
+    return { valid, token: token.Token, data: token }
+  }
+
+  getCachedXstsToken() {
+    let token = this.cache.xstsToken
+    if (!token) return
+    let until = new Date(token.expiresOn)
+    let dn = Date.now()
+    let remainingMs = until - dn
+    let valid = remainingMs > 1000
+    return { valid, token: token.Token, data: token }
+  }
+
+  setCachedUserToken(data) {
+    this.cache.userToken = data
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+  }
+
+  setCachedXstsToken(data) {
+    this.cache.xstsToken = data
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+  }
+
+  async verifyTokens() {
+    let ut = this.getCachedUserToken()
+    let xt = this.getCachedXstsToken()
+    if (!ut || !xt) {
+      return false
+    }
+    debug('[xbl] have user, xsts', ut, xt)
+    if (ut.valid && xt.valid) {
+      return true
+    } else if (ut.valid && !xt.valid) {
+      try {
+        this.getXSTSToken(ut.data)
+      } catch (e) {
+        return false
+      }
+    }
+    return false
+  }
+
+  async getUserToken(msaAccessToken) {
+    debug('[xbl] obtaining xbox token with ms token', msaAccessToken)
+    if (!msaAccessToken.startsWith('d='))
+      msaAccessToken = 'd=' + msaAccessToken // took way too long to figure this out
+    let xblUserToken = await XboxLiveAuth.exchangeRpsTicketForUserToken(msaAccessToken)
+    this.setCachedUserToken(xblUserToken)
+    debug('[xbl] user token:', xblUserToken)
+    return xblUserToken
+  }
+
+  async getXSTSToken(xblUserToken) {
+    debug('[xbl] obtaining xsts token with xbox user token', xblUserToken.Token)
+    let xsts = await XboxLiveAuth.exchangeUserTokenForXSTSIdentity(
+      xblUserToken.Token, { XSTSRelyingParty: this.relayParty, raw: false }
+    )
+    this.setCachedXstsToken(xsts)
+    debug('[xbl] xsts', xsts)
+    return xsts
+  }
+}
+
+// Manages Minecraft tokens for sessionserver.mojang.com 
+class MinecraftTokenManager {
+  constructor({ cacheLocation } = {}) {
+    if (!cacheLocation) cacheLocation = path.join(__dirname, './mca-cache.json')
+    try {
+      this.cache = require(cacheLocation)
+    } catch (e) {
+      this.cache = {}
+    }
+    this.cacheLocation = cacheLocation
+  }
+
+  getCachedAccessToken() {
+    let token = this.cache.mca
+    // console.log('MC token cache', this.cache)
+    if (!token) return
+    let expires = token.obtainedOn + (token.expires_in * 1000)
+    let remaining = expires - Date.now()
+    let valid = remaining > 1000
+    return { valid, until: expires, token: token.access_token, data: token }
+  }
+
+  setCachedAccessToken(data) {
+    data.obtainedOn = Date.now()
+    this.cache.mca = data
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+    // console.log('cached', data, this.cache, this.cacheLocation)
+  }
+
+  async verifyTokens() {
+    let at = this.getCachedAccessToken()
+    if (!at) {
+      return false
+    }
+    debug('[mc] have user access token', at)
+    if (at.valid) {
+      return true
+    }
+    return false
+  }
+
+  async getAccessToken(xsts) {
+    debug('[mc] authing to minecraft', xsts)
+    const MinecraftServicesLogWithXbox = 'https://api.minecraftservices.com/authentication/login_with_xbox'
+    const getFetchOptions = {
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'node-minecraft-protocol'
+      }
+    }
+    const MineServicesResponse = await fetch(MinecraftServicesLogWithXbox, {
+      method: 'post',
+      ...getFetchOptions,
+      body: JSON.stringify({ identityToken: `XBL3.0 x=${xsts.userHash};${xsts.XSTSToken}` })
+    }).then(checkStatus)
+  
+    debug('[mc] mc auth response', MineServicesResponse)
+    this.setCachedAccessToken(MineServicesResponse)
+    return MineServicesResponse.access_token
+  }
+
+  async verifyEntitlements() {
+    // TODO
+  }
+}
+
+if (typeof btoa === 'undefined') {
+  global.btoa = function (str) {
+    return new Buffer(str, 'binary').toString('base64');
+  };
+}
+
+if (typeof atob === 'undefined') {
+  global.atob = function (b64Encoded) {
+    return new Buffer(b64Encoded, 'base64').toString('binary');
+  };
+}
+
+function checkStatus(res) {
+  if (res.ok) { // res.status >= 200 && res.status < 300
+    return res.json()
+  } else {
+    throw Error(res.statusText)
+  }
+}
+
+module.exports = { MsaTokenManager, XboxTokenManager, MinecraftTokenManager }

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -111,7 +111,7 @@ class MsaTokenManager {
       return true
     } else {
       try {
-        this.refreshTokens()
+        await this.refreshTokens()
         return true
       } catch (e) {
         return false
@@ -196,7 +196,8 @@ class XboxTokenManager {
       return true
     } else if (ut.valid && !xt.valid) {
       try {
-        this.getXSTSToken(ut.data)
+        await this.getXSTSToken(ut.data)
+        return true
       } catch (e) {
         return false
       }

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -1,7 +1,7 @@
 const msal = require('@azure/msal-node')
+const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const fs = require('fs')
 const path = require('path')
-const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const fetch = require('node-fetch')
 const authConstants = require('./authConstants')
 
@@ -63,10 +63,9 @@ class MsaTokenManager {
       debug('[msa] No valid access token found', tokens)
       return
     }
-    // console.log(account)
-    const until = (Date.now() - new Date(account.expires_on * 1000))
-    const valid = until < 1000
-    return { valid, until: until * -1, token: account.secret }
+    const until = new Date(account.expires_on * 1000) - Date.now()
+    const valid = until > 1000
+    return { valid, until: until, token: account.secret }
   }
 
   getRefreshToken () {
@@ -136,7 +135,7 @@ class MsaTokenManager {
         if (!this.msaCache.Account) this.msaCache.Account = { '': response.account }
         resolve(response)
       }).catch((error) => {
-        console.warn('[msa] Error getting device_code')
+        console.warn('[msa] Error getting device code')
         console.debug(JSON.stringify(error))
         reject(error)
       })
@@ -288,18 +287,6 @@ class MinecraftTokenManager {
     // TODO
   }
 }
-
-// if (typeof btoa === 'undefined') {
-//   global.btoa = function (str) {
-//     return new Buffer(str, 'binary').toString('base64')
-//   }
-// }
-
-// if (typeof atob === 'undefined') {
-//   global.atob = function (b64Encoded) {
-//     return new Buffer(b64Encoded, 'base64').toString('binary')
-//   }
-// }
 
 function checkStatus (res) {
   if (res.ok) { // res.status >= 200 && res.status < 300

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -10,7 +10,7 @@ function debug (...message) {
 
 // Manages Microsoft account tokens
 class MsaTokenManager {
-  constructor ({ msalConfig, scopes, cacheLocation }) {
+  constructor (msalConfig, scopes, cacheLocation) {
     this.msaClientId = msalConfig.auth.clientId
     this.scopes = scopes
     this.cacheLocation = cacheLocation || path.join(__dirname, './msa-cache.json')
@@ -133,8 +133,8 @@ class MsaTokenManager {
         debug('[msa] device_code resp', JSON.stringify(response))
         resolve(response)
       }).catch((error) => {
-        console.warn('ERROR!', error)
-        console.log('ERROR!', JSON.stringify(error))
+        console.warn('[msa] Error getting device_code')
+        console.debug(JSON.stringify(error))
         reject(error)
       })
     })
@@ -143,7 +143,7 @@ class MsaTokenManager {
 
 // Manages Xbox Live tokens for xboxlive.com
 class XboxTokenManager {
-  constructor ({ relayParty, cacheLocation }) {
+  constructor (relayParty, cacheLocation) {
     this.relayParty = relayParty
     this.cacheLocation = cacheLocation || path.join(__dirname, './xbl-cache.json')
     try {
@@ -224,7 +224,7 @@ class XboxTokenManager {
 
 // Manages Minecraft tokens for sessionserver.mojang.com
 class MinecraftTokenManager {
-  constructor ({ cacheLocation } = {}) {
+  constructor (cacheLocation) {
     this.cacheLocation = cacheLocation || path.join(__dirname, './mca-cache.json')
     try {
       this.cache = require(this.cacheLocation)

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -1,14 +1,10 @@
 const msal = require('@azure/msal-node')
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
-// const debug = require('debug')('minecraft-protocol')
+const debug = require('debug')('minecraft-protocol')
 const fs = require('fs')
 const path = require('path')
 const fetch = require('node-fetch')
 const authConstants = require('./authConstants')
-
-function debug (...message) {
-  console.debug(message[0])
-}
 
 // Manages Microsoft account tokens
 class MsaTokenManager {
@@ -239,7 +235,7 @@ class MinecraftTokenManager {
 
   getCachedAccessToken () {
     const token = this.cache.mca
-    // console.log('MC token cache', this.cache)
+    debug('[mc] token cache', this.cache)
     if (!token) return
     const expires = token.obtainedOn + (token.expires_in * 1000)
     const remaining = expires - Date.now()
@@ -251,7 +247,6 @@ class MinecraftTokenManager {
     data.obtainedOn = Date.now()
     this.cache.mca = data
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
-    // console.log('cached', data, this.cache, this.cacheLocation)
   }
 
   async verifyTokens () {
@@ -283,10 +278,6 @@ class MinecraftTokenManager {
     debug('[mc] mc auth response', MineServicesResponse)
     this.setCachedAccessToken(MineServicesResponse)
     return MineServicesResponse.access_token
-  }
-
-  async verifyEntitlements () {
-    // TODO
   }
 }
 

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -133,7 +133,7 @@ class MsaTokenManager {
     return new Promise((resolve, reject) => {
       this.msalApp.acquireTokenByDeviceCode(deviceCodeRequest).then((response) => {
         debug('[msa] device_code resp', JSON.stringify(response))
-        if (!this.msaCache.Account) this.msaCache.Account = { '': response.account } 
+        if (!this.msaCache.Account) this.msaCache.Account = { '': response.account }
         resolve(response)
       }).catch((error) => {
         console.warn('[msa] Error getting device_code')

--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -133,6 +133,7 @@ class MsaTokenManager {
     return new Promise((resolve, reject) => {
       this.msalApp.acquireTokenByDeviceCode(deviceCodeRequest).then((response) => {
         debug('[msa] device_code resp', JSON.stringify(response))
+        if (!this.msaCache.Account) this.msaCache.Account = { '': response.account } 
         resolve(response)
       }).catch((error) => {
         console.warn('[msa] Error getting device_code')

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -34,11 +34,12 @@ function createClient (options) {
   const client = new Client(false, version.minecraftVersion, options.customPackets, hideErrors)
 
   tcpDns(client, options)
-  if (options.auth == 'microsoft') {
-    if (options.password)
+  if (options.auth === 'microsoft') {
+    if (options.password) { 
       microsoftAuth.authenticatePassword(client, options)
-    else 
+    } else { 
       microsoftAuth.authenticateDeviceToken(client, options)
+    }
   } else {
     auth(client, options)
   }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -38,7 +38,7 @@ function createClient (options) {
     if (options.password) {
       microsoftAuth.authenticatePassword(client, options)
     } else {
-      microsoftAuth.authenticateDeviceToken(client, options)
+      microsoftAuth.authenticateDeviceCode(client, options)
     }
   } else {
     auth(client, options)

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -34,8 +34,14 @@ function createClient (options) {
   const client = new Client(false, version.minecraftVersion, options.customPackets, hideErrors)
 
   tcpDns(client, options)
-  if (options.auth === 'microsoft') microsoftAuth(client, options)
-  else auth(client, options)
+  if (options.auth == 'microsoft') {
+    if (options.password)
+      microsoftAuth.authenticatePassword(client, options)
+    else 
+      microsoftAuth.authenticateDeviceToken(client, options)
+  } else {
+    auth(client, options)
+  }
   if (options.version === false) autoVersion(client, options)
   setProtocol(client, options)
   keepalive(client, options)

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -35,9 +35,9 @@ function createClient (options) {
 
   tcpDns(client, options)
   if (options.auth === 'microsoft') {
-    if (options.password) { 
+    if (options.password) {
       microsoftAuth.authenticatePassword(client, options)
-    } else { 
+    } else {
       microsoftAuth.authenticateDeviceToken(client, options)
     }
   } else {


### PR DESCRIPTION
Fix #791 

* If the `createClient()` is called with `{ auth: 'microsoft', username: 'anyUsername' }`, it tries to authenticate with device code flow and not username and password.
* It first turns the username into a sha1 hash, takes the first few bytes of it into an identifier, uses it to search for token cache files, if not found it goes through the normal auth flow
* If the cache files are found, it checks if the tokens are valid, if they are they get used otherwise the tokens get refreshed

* Adds a `onMsaCode(data)` callback parameter to client options that can receive code info, see electron example for usage

### Test the PR

You can test this PR by running
```
npm i extremeheat/node-minecraft-protocol#msa
```

where you installed mineflayer or node-minecraft-protocol (install mineflayer or nmp *before* you run the command, do not add it to your package.json)

In your `createClient` or `createBot` options, make sure you set `auth: 'microsoft'`.