### PR TITLE
Fix microsoft account caching bug

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ client.on('chat', function(packet) {
 ```
 
 If the server is in offline mode, you may leave out the `password` option.
+You can also leave out `password` when using a Microsoft account. If provided, password based auth will be attempted first which may fail. *Note:* if using a Microsoft account, your account age must be >= 18 years old.
 
 ### Hello World server example
 

--- a/src/client/authFlow.js
+++ b/src/client/authFlow.js
@@ -17,11 +17,12 @@ const msalConfig = {
   }
 }
 
-async function retry (methodFn, beforeRety, times) {
+async function retry (methodFn, beforeRetry, times) {
   while (times--) {
     if (times !== 0) {
       try { return await methodFn() } catch (e) { debug(e) }
-      await beforeRety()
+      await new Promise(resolve => setTimeout(resolve, 2000))
+      await beforeRetry()
     } else {
       return await methodFn()
     }
@@ -104,7 +105,7 @@ class MsAuthFlow {
         const ut = await this.xbl.getUserToken(msaToken)
         const xsts = await this.xbl.getXSTSToken(ut)
         return xsts
-      }, () => { this.msa.forceRefresh = true }, 1)
+      }, () => { this.msa.forceRefresh = true }, 2)
     }
   }
 
@@ -118,7 +119,7 @@ class MsAuthFlow {
         const xsts = await this.getXboxToken()
         debug('[xbl] xsts data', xsts)
         return this.mca.getAccessToken(xsts)
-      }, () => { this.xbl.forceRefresh = true }, 1)
+      }, () => { this.xbl.forceRefresh = true }, 2)
     }
   }
 }


### PR DESCRIPTION
* Fix a bug with microsoft account token caching (previously it would not reload the token db after refreshing the auth token), pulled from https://github.com/PrismarineJS/bedrock-protocol/pull/45