### PR TITLE
fix write to launcher_accounts.json

### DIFF
--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -70,6 +70,7 @@ module.exports = async function (client, options) {
                 const newProfileObj = {
                   accessToken: session.accessToken,
                   minecraftProfile: {
+                    id: session.selectedProfile.id,
                     name: session.selectedProfile.name
                   },
                   userProperites: oldProfileObj ? (oldProfileObj.userProperites || []) : [],


### PR DESCRIPTION
fixed minecraftProfile id missing when writing new profile to launcher_accounts.json, causing yggdrasil to fail when authenticating session