### PR TITLE
Mc.ping return a promise and use callbacks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -219,11 +219,16 @@ Where the key is the numeric metadata key and the value is the value of the
 correct data type. You can figure out the types [here](http://wiki.vg/Entities#Entity_Metadata_Format)
 
 
-## mc.ping(options, callback)
+## mc.ping(options)
 
-Ping a minecraft server and retrieve information about it
+`options` is an object containing the following:
+* host : default too locahost
+* port : default too 25565
+* version: default too most recent version
 
-`callback(err, pingResults)`
+Ping a minecraft server and return a promise containing the information about it
+
+`promise( <pending> ).then(pingResult).catch(err)`
 
 `pingResults`:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -226,7 +226,7 @@ correct data type. You can figure out the types [here](http://wiki.vg/Entities#E
 * port : default too 25565
 * version: default too most recent version
 
-Ping a minecraft server and return a promise or use a callback containing the information about it
+Ping a minecraft server and return a promise or use an optional callback containing the information about it
 
 returns: `promise( <pending> ).then(pingResult).catch(err)`
 callback `callback(err, pingResults)`

--- a/docs/API.md
+++ b/docs/API.md
@@ -219,16 +219,17 @@ Where the key is the numeric metadata key and the value is the value of the
 correct data type. You can figure out the types [here](http://wiki.vg/Entities#Entity_Metadata_Format)
 
 
-## mc.ping(options)
+## mc.ping(options, callback)
 
 `options` is an object containing the following:
 * host : default too locahost
 * port : default too 25565
 * version: default too most recent version
 
-Ping a minecraft server and return a promise containing the information about it
+Ping a minecraft server and return a promise or use a callback containing the information about it
 
-`promise( <pending> ).then(pingResult).catch(err)`
+returns: `promise( <pending> ).then(pingResult).catch(err)`
+callback `callback(err, pingResults)`
 
 `pingResults`:
 

--- a/src/ping.js
+++ b/src/ping.js
@@ -19,22 +19,21 @@ function ping (options, cb) {
   options.noPongTimeout = options.noPongTimeout || 5 * 1000
 
   const client = new Client(false, version.minecraftVersion)
-  return new Promise((resolve, reject)=>{
+  return new Promise((resolve, reject) => {
     client.on('error', function (err) {
       clearTimeout(closeTimer)
-      if(cb){
+      if (cb) {
         cb(err)
       }
       reject(err)
     })
-  
     client.once('server_info', function (packet) {
       const data = JSON.parse(packet.response)
       const start = Date.now()
       const maxTime = setTimeout(() => {
         clearTimeout(closeTimer)
         client.end()
-        if(cb){
+        if (cb) {
           cb(null, data)
         }
         resolve(data)
@@ -44,18 +43,16 @@ function ping (options, cb) {
         clearTimeout(maxTime)
         clearTimeout(closeTimer)
         client.end()
-        if(cb){
+        if (cb) {
           cb(null, data)
         }
         resolve(data)
       })
       client.write('ping', { time: [0, 0] })
     })
-  
     client.on('state', function (newState) {
       if (newState === states.STATUS) { client.write('ping_start', {}) }
     })
-  
     // TODO: refactor with src/client/setProtocol.js
     client.on('connect', function () {
       client.write('set_protocol', {
@@ -66,18 +63,16 @@ function ping (options, cb) {
       })
       client.state = states.STATUS
     })
-  
     // timeout against servers that never reply while keeping
     // the connection open and alive.
     closeTimer = setTimeout(function () {
       client.end()
-      if(cb){
+      if (cb) {
         cb(new Error('ETIMEDOUT'))
       }
       reject(new Error('ETIMEDOUT'))
     }, options.closeTimeout)
-  
     tcpDns(client, options)
     options.connect(client)
-  });
-}
+  })
+};

--- a/src/ping.js
+++ b/src/ping.js
@@ -6,7 +6,7 @@ const tcpDns = require('./client/tcp_dns')
 
 module.exports = ping
 
-function ping (options, cb) {
+function ping (options) {
   options.host = options.host || 'localhost'
   options.port = options.port || 25565
   const optVersion = options.version || require('./version').defaultVersion
@@ -19,51 +19,53 @@ function ping (options, cb) {
   options.noPongTimeout = options.noPongTimeout || 5 * 1000
 
   const client = new Client(false, version.minecraftVersion)
-  client.on('error', function (err) {
-    clearTimeout(closeTimer)
-    cb(err)
-  })
-
-  client.once('server_info', function (packet) {
-    const data = JSON.parse(packet.response)
-    const start = Date.now()
-    const maxTime = setTimeout(() => {
+  return new Promise((resolve, reject)=>{
+    client.on('error', function (err) {
       clearTimeout(closeTimer)
-      cb(null, data)
-      client.end()
-    }, options.noPongTimeout)
-    client.once('ping', function (packet) {
-      data.latency = Date.now() - start
-      clearTimeout(maxTime)
-      clearTimeout(closeTimer)
-      cb(null, data)
-      client.end()
+      reject(err)
     })
-    client.write('ping', { time: [0, 0] })
-  })
-
-  client.on('state', function (newState) {
-    if (newState === states.STATUS) { client.write('ping_start', {}) }
-  })
-
-  // TODO: refactor with src/client/setProtocol.js
-  client.on('connect', function () {
-    client.write('set_protocol', {
-      protocolVersion: options.protocolVersion,
-      serverHost: options.host,
-      serverPort: options.port,
-      nextState: 1
+  
+    client.once('server_info', function (packet) {
+      const data = JSON.parse(packet.response)
+      const start = Date.now()
+      const maxTime = setTimeout(() => {
+        clearTimeout(closeTimer)
+        client.end()
+        resolve(data)
+      }, options.noPongTimeout)
+      client.once('ping', function (packet) {
+        data.latency = Date.now() - start
+        clearTimeout(maxTime)
+        clearTimeout(closeTimer)
+        client.end()
+        resolve(data)
+      })
+      client.write('ping', { time: [0, 0] })
     })
-    client.state = states.STATUS
-  })
-
-  // timeout against servers that never reply while keeping
-  // the connection open and alive.
-  closeTimer = setTimeout(function () {
-    client.end()
-    cb(new Error('ETIMEDOUT'))
-  }, options.closeTimeout)
-
-  tcpDns(client, options)
-  options.connect(client)
+  
+    client.on('state', function (newState) {
+      if (newState === states.STATUS) { client.write('ping_start', {}) }
+    })
+  
+    // TODO: refactor with src/client/setProtocol.js
+    client.on('connect', function () {
+      client.write('set_protocol', {
+        protocolVersion: options.protocolVersion,
+        serverHost: options.host,
+        serverPort: options.port,
+        nextState: 1
+      })
+      client.state = states.STATUS
+    })
+  
+    // timeout against servers that never reply while keeping
+    // the connection open and alive.
+    closeTimer = setTimeout(function () {
+      client.end()
+      reject(new Error('ETIMEDOUT'))
+    }, options.closeTimeout)
+  
+    tcpDns(client, options)
+    options.connect(client)
+  });
 }


### PR DESCRIPTION
It's not a suggestion I've seen however having mc.ping return a promise instead of using a callback will allow for people too use async await on this making for cleaner code.

