### PR TITLE
Add a way to encode a packet only once and send it to multiple clients

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,10 @@ automatically logged in and validated against mojang's auth.
 
 Create a server instance for `version` of minecraft.
 
+### server.writeToClients(clients, name, params)
+
+Write a packet to all `clients` but encode it only once.
+
 ### server.onlineModeExceptions
 
 This is a plain old JavaScript object. Add a key with the username you want to

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,6 +61,7 @@ declare module 'minecraft-protocol' {
 		motd: string
 		onlineModeExceptions: object
 		playerCount: number
+		writeToClients(clients: Client[], name: string, params: any): void
 		close(): void
 		on(event: 'connection', handler: (client: Client) => void): this
 		on(event: 'error', listener: (error: Error) => void): this

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -419,15 +419,15 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
         })
         await Promise.all([once(player1, 'login'), once(player2, 'login')])
         player1.on('chat', (packet) => {
-          assert.deepStrictEqual(packet, { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
+          assert.strictEqual(packet.message, '{"text":"A message from the server."}')
           player1.end()
         })
         player2.on('chat', (packet) => {
-          assert.deepStrictEqual(packet, { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
+          assert.strictEqual(packet.message, '{"text":"A message from the server."}')
           player2.end()
         })
         
-        server.writeToClients(Object.values(server.clients), 'chat', { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
+        server.writeToClients(Object.values(server.clients), 'chat', { message: JSON.stringify({ text: 'A message from the server.' }), position: 1, sender: '00000000-0000-0000-0000-000000000000' })
         await Promise.all([once(player1, 'end'), once(player2, 'end')])
         server.close()
       })

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -419,15 +419,15 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
         })
         await Promise.all([once(player1, 'login'), once(player2, 'login')])
         player1.on('chat', (packet) => {
-          assert.deepStrictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
+          assert.deepStrictEqual(packet, { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
           player1.end()
         })
         player2.on('chat', (packet) => {
-          assert.deepStrictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
+          assert.deepStrictEqual(packet, { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
           player2.end()
         })
         
-        server.writeToClients(Object.values(server.clients), 'chat', { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
+        server.writeToClients(Object.values(server.clients), 'chat', { "message": "{\"text\":\"A message from the server.\"}", "position": 1, "sender": "00000000-0000-0000-0000-000000000000" })
         await Promise.all([once(player1, 'end'), once(player2, 'end')])
         server.close()
       })

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -417,7 +417,7 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
           version: version.minecraftVersion,
           port: PORT
         })
-        await Promise.all(once(player1, 'login'), once(player2, 'login'))
+        await Promise.all([once(player1, 'login'), once(player2, 'login')])
         player1.once('chat', (packet) => {
           assert.strictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '0' })
           player1.end()
@@ -427,7 +427,7 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
           player2.end()
         })
         server.writeToClients([player1, player2], 'chat', { message: '{"text":"A message from the server."}', position: 1, sender: '0' })
-        await Promise.all(once(player1, 'end'), once(player2, 'end'))
+        await Promise.all([once(player1, 'end'), once(player2, 'end')])
         server.close()
       })
     })

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -418,15 +418,16 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
           port: PORT
         })
         await Promise.all([once(player1, 'login'), once(player2, 'login')])
-        player1.once('chat', (packet) => {
-          assert.strictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '0' })
+        player1.on('chat', (packet) => {
+          assert.deepStrictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
           player1.end()
         })
-        player2.once('chat', (packet) => {
-          assert.strictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '0' })
+        player2.on('chat', (packet) => {
+          assert.deepStrictEqual(packet, { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
           player2.end()
         })
-        server.writeToClients([player1, player2], 'chat', { message: '{"text":"A message from the server."}', position: 1, sender: '0' })
+        
+        server.writeToClients(Object.values(server.clients), 'chat', { message: '{"text":"A message from the server."}', position: 1, sender: '00000000-0000-0000-0000-000000000000' })
         await Promise.all([once(player1, 'end'), once(player2, 'end')])
         server.close()
       })

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -68,7 +68,7 @@ mc.supportedVersions.forEach(function (supportedVersion, i) {
   const version = mcData.version
 
   describe('mc-server ' + version.minecraftVersion, function () {
-    this.timeout(5000*2)
+    this.timeout(5000)
     it('starts listening and shuts down cleanly', function (done) {
       const server = mc.createServer({
         'online-mode': false,


### PR DESCRIPTION
Close #713

I assumed this will only be used with clients in "play" state.