### PR TITLE
Make cache path creation recursive

### DIFF
--- a/src/client/authFlow.js
+++ b/src/client/authFlow.js
@@ -41,7 +41,7 @@ class MsAuthFlow {
     let cachePath = cacheDir || mcDefaultFolderPath
     try {
       if (!fs.existsSync(cachePath + '/nmp-cache')) {
-        fs.mkdirSync(cachePath + '/nmp-cache')
+        fs.mkdirSync(cachePath + '/nmp-cache', { recursive: true })
       }
       cachePath += '/nmp-cache'
     } catch (e) {


### PR DESCRIPTION
If cache dir specified or fallback sir does not exist it can error if parent dirs are missing.