### PR TITLE
Functions from src/client accessable and createClient use autoversion if version is not defined

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -277,4 +277,6 @@ Returns a minecraft protocol [serializer](https://github.com/roblabla/ProtoDef#s
 
 Returns a minecraft protocol [deserializer](https://github.com/roblabla/ProtoDef#parserprotomaintype) for these parameters.
 
+## mc.clientFunctions 
 
+The functions within /src/client for more advanced use of the Client class without directly importing them

--- a/src/client/clientFunctions.js
+++ b/src/client/clientFunctions.js
@@ -13,15 +13,15 @@ const pluginChannels = require('./pluginChannels')
 const versionChecking = require('./versionChecking')
 
 module.exports = {
-    encrypt: encrypt,
-    keepalive: keepalive,
-    compress: compress,
-    auth: auth,
-    microsoftAuth: microsoftAuth,
-    setProtocol: setProtocol,
-    play: play,
-    tcpDns: tcpDns,
-    autoVersion: autoVersion,
-    pluginChannels: pluginChannels,
-    versionChecking: versionChecking
+  encrypt: encrypt,
+  keepalive: keepalive,
+  compress: compress,
+  auth: auth,
+  microsoftAuth: microsoftAuth,
+  setProtocol: setProtocol,
+  play: play,
+  tcpDns: tcpDns,
+  autoVersion: autoVersion,
+  pluginChannels: pluginChannels,
+  versionChecking: versionChecking
 }

--- a/src/client/clientFunctions.js
+++ b/src/client/clientFunctions.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const encrypt = require('./encrypt')
 const keepalive = require('./keepalive')
 const compress = require('./compress')
@@ -11,15 +13,15 @@ const pluginChannels = require('./pluginChannels')
 const versionChecking = require('./versionChecking')
 
 module.exports = {
-    encrypt,
-    keepalive,
-    compress,
-    auth,
-    microsoftAuth,
-    setProtocol,
-    play,
-    tcpDns,
-    autoVersion,
-    pluginChannels,
-    versionChecking
+    encrypt: encrypt,
+    keepalive: keepalive,
+    compress: compress,
+    auth: auth,
+    microsoftAuth: microsoftAuth,
+    setProtocol: setProtocol,
+    play: play,
+    tcpDns: tcpDns,
+    autoVersion: autoVersion,
+    pluginChannels: pluginChannels,
+    versionChecking: versionChecking
 }

--- a/src/client/clientFunctions.js
+++ b/src/client/clientFunctions.js
@@ -1,0 +1,25 @@
+const encrypt = require('./encrypt')
+const keepalive = require('./keepalive')
+const compress = require('./compress')
+const auth = require('./auth')
+const microsoftAuth = require('./microsoftAuth')
+const setProtocol = require('./setProtocol')
+const play = require('./play')
+const tcpDns = require('./tcp_dns')
+const autoVersion = require('./autoVersion')
+const pluginChannels = require('./pluginChannels')
+const versionChecking = require('./versionChecking')
+
+module.exports = {
+    encrypt,
+    keepalive,
+    compress,
+    auth,
+    microsoftAuth,
+    setProtocol,
+    play,
+    tcpDns,
+    autoVersion,
+    pluginChannels,
+    versionChecking
+}

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -22,9 +22,8 @@ function createClient (options) {
   assert.ok(options.username, 'username is required')
   if (!options.version) { options.version = false }
 
-  // TODO: avoid setting default version if autoVersion is enabled
+  const defaultVersion = require('./version').defaultVersion
   const optVersion = options.version || (() => {
-    const defaultVersion = require('./version').defaultVersion
     const optVersionClient = new Client(false, defaultVersion)
     const returnClient = autoVersion(optVersionClient, options)
     optVersionClient.end()

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -23,7 +23,16 @@ function createClient (options) {
   if (!options.version) { options.version = false }
 
   // TODO: avoid setting default version if autoVersion is enabled
-  const optVersion = options.version || require('./version').defaultVersion
+  const optVersion = options.version || (() => {
+    const defaultVersion = require('./version').defaultVersion
+    const optVersionClient = new Client(false, defaultVersion)
+    const returnClient = autoVersion(optVersionClient, options)
+    optVersionClient.end()
+    const returnVal = returnClient.version
+    returnClient.end() // TODO: improve this in the future
+    return returnVal
+  }) ()
+
   const mcData = require('minecraft-data')(optVersion)
   if (!mcData) throw new Error(`unsupported protocol version: ${optVersion}`)
   const version = mcData.version
@@ -51,6 +60,6 @@ function createClient (options) {
   compress(client, options)
   pluginChannels(client, options)
   versionChecking(client, options)
-
+  
   return client
 }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -28,9 +28,9 @@ function createClient (options) {
     const returnClient = autoVersion(optVersionClient, options)
     optVersionClient.end()
     const returnVal = returnClient.version
-    returnClient.end() // TODO: improve this in the future
+    returnClient.end() // I am unsure if this is best way too do this
     return returnVal
-  }) ()
+  })()
 
   const mcData = require('minecraft-data')(optVersion)
   if (!mcData) throw new Error(`unsupported protocol version: ${optVersion}`)
@@ -59,6 +59,5 @@ function createClient (options) {
   compress(client, options)
   pluginChannels(client, options)
   versionChecking(client, options)
-  
   return client
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Client = require('./client')
+const clientFunc = require('./client/clientFunctions')
 const Server = require('./server')
 const serializer = require('./transforms/serializer')
 const createClient = require('./createClient')
@@ -8,6 +9,7 @@ const createServer = require('./createServer')
 
 module.exports = {
   createClient: createClient,
+  clientFunctions: clientFunc,
   createServer: createServer,
   Client: Client,
   Server: Server,


### PR DESCRIPTION
It is more convinient too have the functions within src/client be accessable from the main library making it easier too use the function class.
Also using auto version in createClient if version is not defined however I am unsure if this is the best way too do this or if this is needed