### PR TITLE
automatic port "discovery" for packets and server tests

### DIFF
--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -2,7 +2,6 @@
 
 const mc = require('../')
 const os = require('os')
-const net = require('net')
 const path = require('path')
 const assert = require('power-assert')
 const SURVIVE_TIME = 10000
@@ -13,14 +12,7 @@ const Wrap = require('minecraft-wrap').Wrap
 
 const download = util.promisify(require('minecraft-wrap').download)
 
-const getPort = () => new Promise(resolve => {
-  const server = net.createServer()
-  server.listen(0, '127.0.0.1')
-  server.on('listening', () => {
-    const { port } = server.address()
-    server.close(() => resolve(port))
-  })
-})
+const { getPort } = require('./common/util')
 
 for (const supportedVersion of mc.supportedVersions) {
   let PORT = null

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -1,0 +1,12 @@
+const net = require('net')
+
+const getPort = () => new Promise(resolve => {
+  const server = net.createServer()
+  server.listen(0, '127.0.0.1')
+  server.on('listening', () => {
+    const { port } = server.address()
+    server.close(() => resolve(port))
+  })
+})
+
+module.exports = { getPort }

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -8,14 +8,7 @@ const assert = require('power-assert')
 const getFieldInfo = require('protodef').utils.getFieldInfo
 const getField = require('protodef').utils.getField
 
-const getPort = () => new Promise(resolve => {
-  const server = net.createServer()
-  server.listen(0, '127.0.0.1')
-  server.on('listening', () => {
-    const { port } = server.address()
-    server.close(() => resolve(port))
-  })
-})
+const { getPort } = require('./common/util')
 
 function evalCount (count, fields) {
   if (fields[count.field] in count.map) { return count.map[fields[count.field]] }

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -196,24 +196,23 @@ for (const supportedVersion of mc.supportedVersions) {
   const version = mcData.version
   const packets = mcData.protocol
 
-  before(async function () {
-    PORT = await getPort()
-    console.log(`Using port for tests: ${PORT}`)
-  })
-
   describe('packets ' + version.minecraftVersion, function () {
     let client, server, serverClient
-    before(function (done) {
+    before(async function () {
+      PORT = await getPort()
       server = new Server(version.minecraftVersion)
-      server.once('listening', function () {
-        server.once('connection', function (c) {
-          serverClient = c
-          done()
+      return new Promise((resolve) => {
+        console.log(`Using port for tests: ${PORT}`)
+        server.once('listening', function () {
+          server.once('connection', function (c) {
+            serverClient = c
+            resolve()
+          })
+          client = new Client(false, version.minecraftVersion)
+          client.setSocket(net.connect(PORT, 'localhost'))
         })
-        client = new Client(false, version.minecraftVersion)
-        client.setSocket(net.connect(PORT, 'localhost'))
+        server.listen(PORT, 'localhost')
       })
-      server.listen(PORT, 'localhost')
     })
     after(function (done) {
       client.on('end', function () {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -70,17 +70,17 @@ const getPort = () => new Promise(resolve => {
 })
 
 for (const supportedVersion of mc.supportedVersions) {
-  let PORT;
+  let PORT
   const mcData = require('minecraft-data')(supportedVersion)
   const version = mcData.version
 
   describe('mc-server ' + version.minecraftVersion, function () {
 
     this.beforeAll(async function() {
-      PORT = await getPort();
+      PORT = await getPort()
       console.log(`Using port for tests: ${PORT}`)
     })
-    
+
     this.timeout(5000)
     it('starts listening and shuts down cleanly', function (done) {
       const server = mc.createServer({

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -1,9 +1,10 @@
 /* eslint-env mocha */
 
 const mc = require('../')
-const net = require('net')
 const assert = require('power-assert')
 const { once } = require('events')
+
+const { getPort } = require('./common/util')
 
 const w = {
   piglin_safe: {
@@ -59,15 +60,6 @@ const w = {
     value: 0
   }
 }
-
-const getPort = () => new Promise(resolve => {
-  const server = net.createServer()
-  server.listen(0, '127.0.0.1')
-  server.on('listening', () => {
-    const { port } = server.address()
-    server.close(() => resolve(port))
-  })
-})
 
 for (const supportedVersion of mc.supportedVersions) {
   let PORT


### PR DESCRIPTION
This PR builds on https://github.com/PrismarineJS/node-minecraft-protocol/pull/869 by making the other two tests for packets and servers also use port "discovery".