### PR TITLE
Fix 1.7.10 auto versioning

### DIFF
--- a/src/server/handshake.js
+++ b/src/server/handshake.js
@@ -9,7 +9,7 @@ module.exports = function (client, server, { version }) {
     client.serverPort = packet.serverPort
     client.protocolVersion = packet.protocolVersion
     if (version === false || version === undefined) {
-      if (client.protocolVersion === 5) { // The first snapshot versions of 1.8 use the 1.7 protocol id, after 1.8 each snapshot has a different protocol id.
+      if (client.protocolVersion === 5) { // The first snapshot versions of 1.8 uses the 1.7 protocol id, after 1.8 each snapshot has a different protocol id.
         client.version = '1.7.10'
       } else {
         const postNettyVersions = mcData.postNettyVersionsByProtocolVersion.pc[client.protocolVersion]

--- a/src/server/handshake.js
+++ b/src/server/handshake.js
@@ -1,4 +1,3 @@
-const mcData = require('minecraft-data')
 const states = require('../states')
 
 module.exports = function (client, server, { version }) {
@@ -8,13 +7,13 @@ module.exports = function (client, server, { version }) {
     client.serverHost = packet.serverHost
     client.serverPort = packet.serverPort
     client.protocolVersion = packet.protocolVersion
+
     if (version === false || version === undefined) {
       if (client.protocolVersion === 5) { // The first snapshot versions of 1.8 uses the 1.7 protocol id, after 1.8 each snapshot has a different protocol id.
         client.version = '1.7.10'
       } else {
-        const postNettyVersions = mcData.postNettyVersionsByProtocolVersion.pc[client.protocolVersion]
-        if (postNettyVersions && postNettyVersions.length > 0) {
-          client.version = postNettyVersions[0].minecraftVersion
+        if (require('minecraft-data')(client.protocolVersion)) {
+          client.version = client.protocolVersion
         } else {
           client.end('Protocol version ' + client.protocolVersion + ' is not supported')
         }


### PR DESCRIPTION
This fixes the auto versioning. 
1.7.10 has to be hardcoded since the protocol ids of the first 1.8 snapshots use the 1.7 protocol id.
![problem](https://user-images.githubusercontent.com/29002908/127769022-665dd464-b3ca-43ce-bd38-c7bc25f72ae8.png)
