### PR TITLE
Improve Typescript definitions and API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -134,7 +134,7 @@ If `fullReason` is not defined, then the `reason` will be used.
 
 ### client.connect(port, host)
 
-TODO
+Used by the [Client Class](https://github.com/PrismarineJS/node-minecraft-protocol/blob/d9d01c8be4921bb38e7b59d9c18afd771615ba22/src/client.js) to connect to a server, done by createClient automatically
 
 ### client.setSocket(socket)
 
@@ -210,7 +210,7 @@ and the packet metadata (name, state)
 
 ### `connect` event
 
-TODO: Clarify what this is
+when the socket connects to the server, this is emitted
 
 ### `end` event
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -109,6 +109,7 @@ Returns a `Client` instance and perform login.
    * (microsoft account) the path to store authentication caches, defaults to .minecraft
  * onMsaCode(data) : (optional) callback called when signing in with a microsoft account
  with device code auth. `data` is an object documented [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#device-authorization-response)
+ * id : a numeric client id used for referring to multiple clients in a server
 
 
 ## mc.Client(isServer,version,[customPackets])
@@ -120,12 +121,36 @@ Takes a minecraft `version` as second argument.
 
 write a packet
 
+### client.writeRaw(buffer)
+
+write a raw buffer as a packet
+
 ### client.end(reason, fullReason)
 
 Ends the connection with `reason` or `fullReason`
 If `fullReason` is not defined, then the `reason` will be used.
 
 `fullReason` is a JSON object, which represents [chat](https://wiki.vg/Chat) message.
+
+### client.connect(port, host)
+
+TODO
+
+### client.setSocket(socket)
+
+Sets the client's connection socket.
+
+### client.registerChannel(name, typeDefinition, custom)
+
+Registers a plugin channel with the given `name` and protodef `typeDefinition`
+
+### client.unregisterChannel(name)
+
+Unregisters a plugin channel.
+
+### client.writeChannel(channel, params)
+
+TODO: clarify what the heck this does exactly
 
 ### client.state
 
@@ -136,7 +161,6 @@ packet parsing. This is one of the protocol.states.
 
 True if this is a connection going from the server to the client,
 False if it is a connection from client to server.
-
 
 ### client.socket
 
@@ -163,6 +187,18 @@ The player's profile, as returned by the Yggdrasil system. (only server-side)
 
 The latency of the client, in ms. Updated at each keep alive.
 
+### client.customPackets
+
+An object index by version/state/direction/name, see client_custom_packet for an example
+
+### client.protocolVersion
+
+The client's protocol version
+
+### client.version
+
+The client's version
+
 ### `packet` event
 
 Called with every packet parsed. Takes four paramaters, the JSON data we parsed, the packet metadata (name, state), the buffer (raw data) and the full buffer (includes surplus data and may include the data of following packets on versions below 1.8) 
@@ -172,14 +208,26 @@ Called with every packet parsed. Takes four paramaters, the JSON data we parsed,
 Called with every packet, but as a buffer. Takes two params, the buffer
 and the packet metadata (name, state)
 
+### `connect` event
+
+TODO: Clarify what this is
+
+### `end` event
+
+Called when the client's connection is disconnected. Takes the reason as parameter
+
+### `session` event
+
+Called when user authentication is resolved. Takes session data as parameter.
+
 ### `state` event
 
 Called when the protocol changes state. Takes the new state and old state as
 parameters.
 
-### `session` event
+### `error` event
 
-Called when user authentication is resolved. Takes session data as parameter.
+Called when an error occurs within the client. Takes an Error as parameter.
 
 ### per-packet events
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -150,7 +150,7 @@ Unregisters a plugin channel.
 
 ### client.writeChannel(channel, params)
 
-TODO: clarify what the heck this does exactly
+Write to [Plugin Channels](https://wiki.vg/Plugin_channels)
 
 ### client.state
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,23 +8,23 @@ import { Agent } from 'http'
 declare module 'minecraft-protocol' {
 	export class Client extends EventEmitter {
 		constructor(isServer: boolean, version: string, customPackets?: any)
-		customPackets: any
-		isServer: boolean
-		latency: number
-		profile: any
-		session: any
-		socket: Socket
 		state: States
-		username: string
+		isServer: boolean
+		socket: Socket
 		uuid: string
+		username: string
+		session?: any
+		profile?: any
+		latency: number
+		customPackets: any
 		protocolVersion: number
 		version: string
+		write(name: string, params: any): void
+		end(reason: string): void
 		connect(port: number, host: string): void
 		setSocket(socket: Socket): void
-		end(reason: string): void
 		registerChannel(name: string, typeDefinition: any, custom?: boolean): void
 		unregisterChannel(name: string): void
-		write(name: string, params: any): void
 		writeRaw(buffer: any): void
 		writeChannel(channel: any, params: any): void
 		on(event: 'error', listener: (error: Error) => void): this
@@ -39,34 +39,40 @@ declare module 'minecraft-protocol' {
 	}
 
 	export interface ClientOptions {
-		accessToken?: string
-		checkTimeoutInterval?: number
+		username: string
+		port?: number
+		auth?: 'mojang' | 'microsoft'
+		password?: string
+		host?: string
 		clientToken?: string
+		accessToken?: string
+		authServer?: string
+		sessionServer?: string
+		keepAlive?: boolean
+		closeTimeout?: number 
+		noPongTimeout?: number
+		checkTimeoutInterval?: number
+		version?: string
 		customPackets?: any
 		hideErrors?: boolean
-		host?: string
-		keepAlive?: boolean
-		password?: string
-		port?: number
-		username: string
-		version?: string
 		skipValidation?: boolean
 		stream?: Stream
 		connect?: (client: Client) => void
 		agent?: Agent
-		auth?: 'mojang' | 'microsoft'
+		profilesFolder?: string
+		onMsaCode?: (data: MicrosoftDeviceAuthorizationResponse) => void
 		id?: number
 	}
 
 	export class Server extends EventEmitter {
 		constructor(version: string, customPackets?: any)
+		writeToClients(clients: Client[], name: string, params: any): void
+		onlineModeExceptions: object
 		clients: ClientsMap
-		favicon: string
+		playerCount: number
 		maxPlayers: number
 		motd: string
-		onlineModeExceptions: object
-		playerCount: number
-		writeToClients(clients: Client[], name: string, params: any): void
+		favicon: string
 		close(): void
 		on(event: 'connection', handler: (client: Client) => void): this
 		on(event: 'error', listener: (error: Error) => void): this
@@ -75,20 +81,20 @@ declare module 'minecraft-protocol' {
 	}
 
 	export interface ServerOptions {
-		'online-mode'?: boolean
-		checkTimeoutInterval?: number
-		customPackets?: any
-		hideErrors?: boolean
-		host?: string
-		keepAlive?: boolean
-		kickTimeout?: number
-		maxPlayers?: number
-		motd?: string
 		port?: number
-		version?: string
+		host?: string
+		kickTimeout?: number
+		checkTimeoutInterval?: number
+		'online-mode'?: boolean
 		beforePing?: (response: any, client: Client, callback?: (result: any) => any) => any
 		beforeLogin?: (client: Client) => void
+		motd?: string
+		maxPlayers?: number
+		keepAlive?: boolean
+		version?: string
+		customPackets?: any
 		errorHandler?: (client: Client, error: Error) => void
+		hideErrors?: boolean
 		agent?: Agent
 	}
 
@@ -97,6 +103,15 @@ declare module 'minecraft-protocol' {
 		isServer?: boolean
 		state?: States
 		version: string
+	}
+	
+	export interface MicrosoftDeviceAuthorizationResponse {
+		device_code: string
+		user_code: string
+		verification_uri: string
+		expires_in: number
+		interval: number
+		message: string
 	}
 
 	enum States {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,20 +20,20 @@ declare module 'minecraft-protocol' {
 		protocolVersion: number
 		version: string
 		write(name: string, params: any): void
+		writeRaw(buffer: any): void
 		end(reason: string): void
 		connect(port: number, host: string): void
 		setSocket(socket: Socket): void
 		registerChannel(name: string, typeDefinition: any, custom?: boolean): void
 		unregisterChannel(name: string): void
-		writeRaw(buffer: any): void
 		writeChannel(channel: any, params: any): void
-		on(event: 'error', listener: (error: Error) => void): this
 		on(event: 'packet', handler: (data: any, packetMeta: PacketMeta, buffer: Buffer, fullBuffer: Buffer) => void): this
 		on(event: 'raw', handler: (buffer: Buffer, packetMeta: PacketMeta) => void): this
+		on(event: 'connect', handler: () => unknown): this
+		on(event: 'end', handler: (reason: string) => void): this
 		on(event: 'session', handler: (session: any) => void): this
 		on(event: 'state', handler: (newState: States, oldState: States) => void): this
-		on(event: 'end', handler: (reason: string) => void): this
-		on(event: 'connect', handler: () => unknown): this
+		on(event: 'error', listener: (error: Error) => void): this
 		on(event: string, handler: (data: any, packetMeta: PacketMeta) => unknown): this
 		on(event: `raw.${string}`, handler: (buffer: Buffer, packetMeta: PacketMeta) => unknown): this
 	}


### PR DESCRIPTION
This started out as a small PR to copy missing properties and methods from API.md to the typescript definition file, but as I discovered things in the typescript definitions that aren't in API.md I decided to try my best at adding those in too. The overall goal is to reach a state where API.md and the typescript definitions have no differences.

There are several places in API.md where I need confirmation on what some properties are/what some methods do. I've also reorganized some things so I think it makes sense, and I've ordered the typescript definitions for Server, ServerOptions, Client, and ClientOptions to match the order of API.md so discrepencies can be noticed and fixed more easily.