### PR TITLE
Update ping function return type and make callback optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -196,5 +196,5 @@ declare module 'minecraft-protocol' {
 	export function createSerializer({ state, isServer, version, customPackets }: SerializerOptions): any
 	export function createDeserializer({ state, isServer, version, customPackets }: SerializerOptions): any
 
-	export function ping(options: PingOptions, callback: (error: Error, result: OldPingResult | NewPingResult) => void): void
+	export function ping(options: PingOptions, callback?: (error: Error, result: OldPingResult | NewPingResult) => void): Promise<OldPingResult | NewPingResult>
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,6 +157,8 @@ declare module 'minecraft-protocol' {
 		port?: number
 		protocolVersion?: string
 		version?: string
+		closeTimeout?: number
+		noPongTimeout?: number
 	}
 
 	export interface OldPingResult {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -166,7 +166,7 @@ declare module 'minecraft-protocol' {
 		motd: string
 		playerCount: number
 		prefix: string
-		protocol: string
+		protocol: number
 		version: string
 	}
 
@@ -184,7 +184,7 @@ declare module 'minecraft-protocol' {
 		}
 		version: {
 			name: string
-			protocol: string
+			protocol: number
 		}
 		favicon: string
 		latency: number

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -171,7 +171,9 @@ declare module 'minecraft-protocol' {
 	}
 
 	export interface NewPingResult {
-		description: string
+		description: {
+			text: string
+		} | string
 		players: {
 			max: number
 			online: number

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -172,12 +172,13 @@ declare module 'minecraft-protocol' {
 
 	export interface NewPingResult {
 		description: {
-			text: string
+			text?: string
+			extra?: any[]
 		} | string
 		players: {
 			max: number
 			online: number
-			sample: {
+			sample?: {
 				id: string
 				name: string
 			}[]
@@ -186,7 +187,7 @@ declare module 'minecraft-protocol' {
 			name: string
 			protocol: number
 		}
-		favicon: string
+		favicon?: string
 		latency: number
 	}
 


### PR DESCRIPTION
EDIT: Add `closeTimeout` and `noPongTimeout` options to `PingOptions`
EDIT2: Fix `NewPingResult.description` type to reflect accurate results, mix of string or object containing text property
EDIT3: Changed `protocol` to number type to reflect actual type
EDIT4: Update NewPingResult to reflect database of actual responses from various server and proxy ping responses