### PR TITLE
Fixed TypeScript error TS2769 when authenticating with mojang

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -60,6 +60,7 @@ declare module 'minecraft-protocol' {
 		clientToken?: string
 		accessToken?: string
 		authServer?: string
+		authTitle?: string
 		sessionServer?: string
 		keepAlive?: boolean
 		closeTimeout?: number 


### PR DESCRIPTION
Fixed TypeScript Typing Error TS2769: No overload matches this call.