### PR TITLE
add reasons for client.end() & fix issues

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -142,7 +142,7 @@ class Client extends EventEmitter {
       this.socket.removeListener('close', endSocket)
       this.socket.removeListener('end', endSocket)
       this.socket.removeListener('timeout', endSocket)
-      this.emit('end', this._endReason || 'SocketClosed')
+      this.emit('end', this._endReason || 'socketClosed')
     }
 
     const onFatalError = (err) => {

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -15,7 +15,7 @@ module.exports = function (client, options) {
       if (err) {
         debug(err)
         client.emit('error', err)
-        client.end()
+        client.end('encryptionSecretError')
         return
       }
       if (options.haveCredentials) {
@@ -30,7 +30,7 @@ module.exports = function (client, options) {
       function onJoinServerResponse (err) {
         if (err) {
           client.emit('error', err)
-          client.end()
+          client.end('encryptionLoginError')
         } else {
           sendEncryptionKeyResponse()
         }

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -14,7 +14,10 @@ module.exports = function (client, options) {
 
   function onKeepAlive (packet) {
     if (timeout) { clearTimeout(timeout) }
-    timeout = setTimeout(() => client.end(`client timed out after ${checkTimeoutInterval} milliseconds`), checkTimeoutInterval)
+    timeout = setTimeout(() => {
+      client.emit('error', `client timed out after ${checkTimeoutInterval} milliseconds`)
+      client.end('keepAliveError')
+    }, checkTimeoutInterval)
     client.write('keep_alive', {
       keepAliveId: packet.keepAliveId
     })

--- a/src/client/keepalive.js
+++ b/src/client/keepalive.js
@@ -15,7 +15,7 @@ module.exports = function (client, options) {
   function onKeepAlive (packet) {
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(() => {
-      client.emit('error', `client timed out after ${checkTimeoutInterval} milliseconds`)
+      client.emit('error', new Error(`client timed out after ${checkTimeoutInterval} milliseconds`))
       client.end('keepAliveError')
     }, checkTimeoutInterval)
     client.write('keep_alive', {

--- a/src/client/versionChecking.js
+++ b/src/client/versionChecking.js
@@ -12,8 +12,8 @@ module.exports = function (client, options) {
     }
 
     if (!versionRequired) { return }
-    client.end()
     client.emit('error', new Error('This server is version ' + versionRequired +
-      ', you are using version ' + client.version + ', please specify the correct version in the options.'))
+    ', you are using version ' + client.version + ', please specify the correct version in the options.'))
+    client.end('differentVersionError')
   })
 }

--- a/src/ping.js
+++ b/src/ping.js
@@ -34,6 +34,7 @@ function ping (options) {
   return new Promise((resolve, reject) => {
     client.on('error', function (err) {
       clearTimeout(closeTimer)
+      client.end()
       reject(err)
     })
     client.once('server_info', function (packet) {


### PR DESCRIPTION
add client.end() when ping.js fails

added reasons in encrypt.js

switched order of error event and client.end() in versionChecking.js

added an error emitter for keepAliveTimeout

https://github.com/PrismarineJS/mineflayer/pull/2357