### PR TITLE
Fix proxy example not working for servers running in offline mode

### DIFF
--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -96,7 +96,8 @@ srv.on('login', function (client) {
     port: port,
     username: client.username,
     keepAlive: false,
-    version: version
+    version: version,
+    skipValidation: true
   })
   client.on('packet', function (data, meta) {
     if (targetClient.state === states.PLAY && meta.state === states.PLAY) {


### PR DESCRIPTION
Some yggdrasil authentication attempt somehow fails when trying to connect to an offline server making the proxy fail to connect.