### PR TITLE
fix: cross version ping

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,7 @@ automatically logged in and validated against mojang's auth.
  * motd : default to "A Minecraft server"
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
- * version : 1.8 or 1.9 : default to 1.8
+ * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.
  * favicon (optional) : the favicon to set, base64 encoded
  * customPackets (optional) : an object index by version/state/direction/name, see client_custom_packet for an example
  * errorHandler : A way to override the default error handler for client errors. A function that takes a Client and an error.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -142,7 +142,7 @@ declare module 'minecraft-protocol' {
 		motd?: string
 		maxPlayers?: number
 		keepAlive?: boolean
-		version?: string
+		version?: string | false
 		favicon?: string
 		customPackets?: any
 		errorHandler?: (client: Client, error: Error) => void

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -1,15 +1,23 @@
 const endianToggle = require('endian-toggle')
 
-module.exports = function (client, server, { beforePing = null }) {
+module.exports = function (client, server, { beforePing = null, version }) {
   client.once('ping_start', onPing)
   client.once('legacy_server_list_ping', onLegacyPing)
 
   function onPing () {
+    // Use client version if dynamic cross version support is enabled.
+    const responseVersion = (version === false)
+      ? {
+          name: client.version,
+          protocol: client.protocolVersion
+        }
+      : {
+          name: server.mcversion.minecraftVersion,
+          protocol: server.mcversion.version
+        }
+
     const response = {
-      version: {
-        name: server.mcversion.minecraftVersion,
-        protocol: server.mcversion.version
-      },
+      version: responseVersion,
       players: {
         max: server.maxPlayers,
         online: server.playerCount,


### PR DESCRIPTION
Enable dynamic cross version support for ping by responding with the client version and protocol version if dynamic cross version support is enabled.

Additional preparatory steps:
- **docs: explain version parameter https://github.com/PrismarineJS/node-minecraft-protocol/commit/006aabf20a17795ebe86ad382e1b16675430e902**
  Explain version parameter more explicitly. Remove reference to outdated versions. Describe dynamic cross version support with parameter value `false`.
- **fix(types): allow boolean value for version parameter https://github.com/PrismarineJS/node-minecraft-protocol/commit/a4bda0f9a95f01686fd114062607ec5b20951bc2**
  Allow boolean value for version parameter. This makes dynamic cross version support usable in typescript projects.

References https://github.com/PrismarineJS/node-minecraft-protocol/pull/508#issuecomment-1082092675

Please be extra cautious while reviewing. I have not been able to test this out properly. Thank you very much :)