### PR TITLE
Fallback version for dynamic versions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ automatically logged in and validated against mojang's auth.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.
- * fallbackVersion : the version that should be used as a fallback, if the client version isn't supported, only works with dynamic cross version support.
+ * fallbackVersion (optional) : the version that should be used as a fallback, if the client version isn't supported, only works with dynamic cross version support.
  * favicon (optional) : the favicon to set, base64 encoded
  * customPackets (optional) : an object index by version/state/direction/name, see client_custom_packet for an example
  * errorHandler : A way to override the default error handler for client errors. A function that takes a Client and an error.

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,7 @@ automatically logged in and validated against mojang's auth.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.
+ * fallbackVersion : the version that should be used as a fallback, if the client version isn't supported, only works with dynamic cross version support.
  * favicon (optional) : the favicon to set, base64 encoded
  * customPackets (optional) : an object index by version/state/direction/name, see client_custom_packet for an example
  * errorHandler : A way to override the default error handler for client errors. A function that takes a Client and an error.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -164,6 +164,7 @@ declare module 'minecraft-protocol' {
 		maxPlayers?: number
 		keepAlive?: boolean
 		version?: string | false
+		fallbackVersion?: string
 		favicon?: string
 		customPackets?: any
 		errorHandler?: (client: Client, error: Error) => void

--- a/src/server/handshake.js
+++ b/src/server/handshake.js
@@ -8,7 +8,7 @@ module.exports = function (client, server, { version, fallbackVersion }) {
     client.serverPort = packet.serverPort
     client.protocolVersion = packet.protocolVersion
 
-    if (version === false || version === undefined) {
+    if (version === false) {
       if (require('minecraft-data')(client.protocolVersion)) {
         client.version = client.protocolVersion
       } else {

--- a/src/server/handshake.js
+++ b/src/server/handshake.js
@@ -1,6 +1,6 @@
 const states = require('../states')
 
-module.exports = function (client, server, { version }) {
+module.exports = function (client, server, { version, fallbackVersion }) {
   client.once('set_protocol', onHandshake)
 
   function onHandshake (packet) {
@@ -12,7 +12,15 @@ module.exports = function (client, server, { version }) {
       if (require('minecraft-data')(client.protocolVersion)) {
         client.version = client.protocolVersion
       } else {
-        client.end('Protocol version ' + client.protocolVersion + ' is not supported')
+        let fallback
+        if (fallbackVersion !== undefined) {
+          fallback = require('minecraft-data')(fallbackVersion)
+        }
+        if (fallback) {
+          client.version = fallback.version.version
+        } else {
+          client.end('Protocol version ' + client.protocolVersion + ' is not supported')
+        }
       }
     } else if (client.protocolVersion !== server.mcversion.version && packet.nextState !== 1) {
       client.end('Wrong protocol version, expected: ' + server.mcversion.version + ' and you are using: ' + client.protocolVersion)

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -10,7 +10,7 @@ module.exports = function (client, server, { beforePing = null, version, fallbac
       protocol: server.mcversion.version
     }
 
-    if (version === false || version === undefined) {
+    if (version === false) {
       let minecraftData = require('minecraft-data')(client.protocolVersion)
       if (!minecraftData && fallbackVersion !== undefined) {
         minecraftData = require('minecraft-data')(fallbackVersion)

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -1,20 +1,32 @@
 const endianToggle = require('endian-toggle')
 
-module.exports = function (client, server, { beforePing = null, version }) {
+module.exports = function (client, server, { beforePing = null, version, fallbackVersion }) {
   client.once('ping_start', onPing)
   client.once('legacy_server_list_ping', onLegacyPing)
 
   function onPing () {
-    // Use client version if dynamic cross version support is enabled.
-    const responseVersion = (version === false)
-      ? {
+    let responseVersion = {
+      name: server.mcversion.minecraftVersion,
+      protocol: server.mcversion.version
+    }
+
+    if (version === false || version === undefined) {
+      let minecraftData = require('minecraft-data')(client.protocolVersion)
+      if (!minecraftData && fallbackVersion !== undefined) {
+        minecraftData = require('minecraft-data')(fallbackVersion)
+      }
+      if (minecraftData) {
+        responseVersion = {
+          name: minecraftData.version.minecraftVersion,
+          protocol: minecraftData.version.version
+        }
+      } else {
+        responseVersion = {
           name: client.version,
           protocol: client.protocolVersion
         }
-      : {
-          name: server.mcversion.minecraftVersion,
-          protocol: server.mcversion.version
-        }
+      }
+    }
 
     const response = {
       version: responseVersion,


### PR DESCRIPTION
This adds an optional `fallbackVersion` server option which is used as protocol version if dynamic version support is enabled (through `version: false`) but the client version is not supported. This allows to at least attempt communication with the client if they are on a different version, e.g. a new release version that isn't yet supported but might have a similar basic protocol.