### PR TITLE
Export defaultVersion

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -325,6 +325,10 @@ The minecraft protocol states.
 
 The supported minecraft versions.
 
+## mc.defaultVersion
+
+The current default minecraft version.
+
 ## mc.createSerializer({ state = states.HANDSHAKING, isServer = false , version})
 
 Returns a minecraft protocol [serializer](https://github.com/roblabla/ProtoDef#serializerprotomaintype) for these parameters.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -245,7 +245,8 @@ declare module 'minecraft-protocol' {
 	}
 
 	export const states: typeof States
-	export const supportedVersions: ['1.7', '1.8', '1.9', '1.10', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.5', '1.17.1']
+	export const supportedVersions: string[]
+	export const defaultVersion: string
 
 	export function createServer(options: ServerOptions): Server
 	export function createClient(options: ClientOptions): Client

--- a/src/index.js
+++ b/src/index.js
@@ -15,5 +15,6 @@ module.exports = {
   createSerializer: serializer.createSerializer,
   createDeserializer: serializer.createDeserializer,
   ping: require('./ping'),
-  supportedVersions: require('./version').supportedVersions
+  supportedVersions: require('./version').supportedVersions,
+  defaultVersion: require('./version').defaultVersion
 }


### PR DESCRIPTION
This adds the `defaultVersion` to the exported fields of this module. This can be useful to set the version or the fallback version (see https://github.com/PrismarineJS/node-minecraft-protocol/pull/983) to the current default version. I've also replaced the type definition of `supportedVersions` with the correct type.