### PR TITLE
Added optional callback to individually decide about verification

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,7 @@ automatically logged in and validated against mojang's auth.
  * hideErrors : do not display errors, default to false
  * agent : a http agent that can be used to set proxy settings for yggdrasil authentication confirmation (see proxy-agent on npm)
  * validateChannelProtocol (optional) : whether or not to enable protocol validation for custom protocols using plugin channels for the connected clients. Defaults to true
+ * shouldVerifyClient (optional) : a callback function to decide if verification (online mode login) is required individually for each client, takes a Client as first argument and returns a boolean, can be async
 
 ## mc.Server(version,[customPackets])
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,7 +28,7 @@ automatically logged in and validated against mojang's auth.
  * hideErrors : do not display errors, default to false
  * agent : a http agent that can be used to set proxy settings for yggdrasil authentication confirmation (see proxy-agent on npm)
  * validateChannelProtocol (optional) : whether or not to enable protocol validation for custom protocols using plugin channels for the connected clients. Defaults to true
- * shouldVerifyClient (optional) : a callback function to decide if verification (online mode login) is required individually for each client, takes a Client as first argument and returns a boolean, can be async
+ * shouldVerifyClient (optional) : a callback function to decide if verification (online mode login) is required individually for each client, e.g. to only verify users connecting with certain addresses. Takes a Client as first argument and returns a boolean, can be async
 
 ## mc.Server(version,[customPackets])
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -169,7 +169,8 @@ declare module 'minecraft-protocol' {
 		errorHandler?: (client: Client, error: Error) => void
 		hideErrors?: boolean
 		agent?: Agent
-		validateChannelProtocol?: boolean
+		validateChannelProtocol?: boolean,
+		shouldVerifyClient?: (client: Client) => boolean | Promise<boolean>
 	}
 
 	export interface SerializerOptions {

--- a/src/server/login.js
+++ b/src/server/login.js
@@ -32,7 +32,7 @@ module.exports = function (client, server, options) {
     if (typeof options.shouldVerifyClient === 'function') {
       needToVerify = await options.shouldVerifyClient(client)
     }
-    if (typeof needToVerify !== 'function') {
+    if (typeof needToVerify !== 'boolean') {
       const isException = !!server.onlineModeExceptions[client.username.toLowerCase()]
       needToVerify = (onlineMode && !isException) || (!onlineMode && isException)
     }
@@ -109,8 +109,7 @@ module.exports = function (client, server, options) {
   }
 
   function loginClient () {
-    const isException = !!server.onlineModeExceptions[client.username.toLowerCase()]
-    if (onlineMode === false || isException) {
+    if (!needToVerify) {
       client.uuid = nameToMcOfflineUUID(client.username)
     }
     options.beforeLogin?.(client)


### PR DESCRIPTION
This adds an optional `shouldVerifyClient` server option to specify a callback function that's called in the login process to individually decide for each client if the online mode verification is required or not. There already is an array of username exceptions `server.onlineModeExceptions` but this doesn't allow deciding based on other factors like the used server address. 