### PR TITLE
Allow false as beforePing callback result to ignore pings

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,7 @@ automatically logged in and validated against mojang's auth.
  * beforePing : allow customisation of the answer to ping the server does. 
  It takes a function with argument response and client, response is the default json response, and client is client who sent a ping.
  It can take as third argument a callback. If the callback is passed, the function should pass its result to the callback, if not it should return.
+ If the result is `false` instead of a response object then the connection is terminated and no ping is returned to the client.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -29,7 +29,11 @@ module.exports = function (client, server, { beforePing = null, version }) {
 
     function answerToPing (err, response) {
       if (err) return
-      client.write('server_info', { response: JSON.stringify(response) })
+      if (response === false) {
+        client.socket.destroy()
+      } else {
+        client.write('server_info', { response: JSON.stringify(response) })
+      }
     }
 
     if (beforePing) {


### PR DESCRIPTION
This adds the ability to return `false` in the `beforePing` callback or passing `false` to the callback in the third argument to ignore pings by terminating the connection. This can be used to block pings to invalid or unwanted server addresses.