### PR TITLE
Don't throw errors in framing Splitter class if hideErrors is enabled

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -19,7 +19,7 @@ class Client extends EventEmitter {
     this.customPackets = customPackets
     this.version = version
     this.isServer = !!isServer
-    this.splitter = framing.createSplitter()
+    this.splitter = framing.createSplitter(hideErrors)
     this.packetsToParse = {}
     this.compressor = null
     this.framer = framing.createFramer()

--- a/src/client.js
+++ b/src/client.js
@@ -163,6 +163,7 @@ class Client extends EventEmitter {
     this.socket.on('end', endSocket)
     this.socket.on('timeout', endSocket)
     this.framer.on('error', onError)
+    this.splitter.on('error', onError)
     this.splitter.on('fatal-error', onFatalError)
 
     this.socket.pipe(this.splitter)

--- a/src/client.js
+++ b/src/client.js
@@ -163,8 +163,7 @@ class Client extends EventEmitter {
     this.socket.on('end', endSocket)
     this.socket.on('timeout', endSocket)
     this.framer.on('error', onError)
-    this.splitter.on('error', onError)
-    this.splitter.on('fatal-error', onFatalError)
+    this.splitter.on('error', onFatalError)
 
     this.socket.pipe(this.splitter)
     this.framer.pipe(this.socket)

--- a/src/client.js
+++ b/src/client.js
@@ -19,7 +19,7 @@ class Client extends EventEmitter {
     this.customPackets = customPackets
     this.version = version
     this.isServer = !!isServer
-    this.splitter = framing.createSplitter(hideErrors)
+    this.splitter = framing.createSplitter()
     this.packetsToParse = {}
     this.compressor = null
     this.framer = framing.createFramer()
@@ -163,7 +163,7 @@ class Client extends EventEmitter {
     this.socket.on('end', endSocket)
     this.socket.on('timeout', endSocket)
     this.framer.on('error', onError)
-    this.splitter.on('error', onError)
+    this.splitter.on('fatal-error', onFatalError)
 
     this.socket.pipe(this.splitter)
     this.framer.pipe(this.socket)

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -52,7 +52,7 @@ class Splitter extends Transform {
       ({ value, size } = readVarInt(this.buffer, offset))
     } catch (e) {
       if (!(e.partialReadError)) {
-        this.emit('fatal-error', e)
+        this.emit('error', e)
       } else { stop = true }
     }
     if (!stop) {
@@ -65,7 +65,7 @@ class Splitter extends Transform {
           if (e.partialReadError) {
             break
           } else {
-            this.emit('fatal-error', e)
+            this.emit('error', e)
           }
         }
       }

--- a/src/transforms/framing.js
+++ b/src/transforms/framing.js
@@ -3,8 +3,8 @@
 const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 const Transform = require('readable-stream').Transform
 
-module.exports.createSplitter = function (hideErrors = false) {
-  return new Splitter(hideErrors)
+module.exports.createSplitter = function () {
+  return new Splitter()
 }
 
 module.exports.createFramer = function () {
@@ -25,9 +25,8 @@ class Framer extends Transform {
 const LEGACY_PING_PACKET_ID = 0xfe
 
 class Splitter extends Transform {
-  constructor (hideErrors = false) {
+  constructor () {
     super()
-    this.hideErrors = hideErrors
     this.buffer = Buffer.alloc(0)
     this.recognizeLegacyPing = false
   }
@@ -53,7 +52,7 @@ class Splitter extends Transform {
       ({ value, size } = readVarInt(this.buffer, offset))
     } catch (e) {
       if (!(e.partialReadError)) {
-        if (!this.hideErrors) throw e
+        this.emit('fatal-error', e)
       } else { stop = true }
     }
     if (!stop) {
@@ -66,7 +65,7 @@ class Splitter extends Transform {
           if (e.partialReadError) {
             break
           } else {
-            if (!this.hideErrors) throw e
+            this.emit('fatal-error', e)
           }
         }
       }


### PR DESCRIPTION
Currently, the server occasionally crashes with an error thrown in the `Splitter` class in the `framing.js` module:

```
.../node_modules/minecraft-protocol/src/transforms/framing.js:67
          } else { throw e }
                   ^
RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 377. Received -939024210
    at new NodeError (node:internal/errors:371:5)
    at boundsError (node:internal/buffer:86:9)
    at Buffer.readUInt8 (node:internal/buffer:252:5)
    at readVarInt (/aternos/nodejs/hypnos/node_modules/protodef/src/datatypes/utils.js:70:22)
    at Splitter._transform (/aternos/nodejs/hypnos/node_modules/minecraft-protocol/src/transforms/framing.js:63:30)
    at Splitter.Transform._read (/aternos/nodejs/hypnos/node_modules/readable-stream/lib/_stream_transform.js:177:10)
    at Splitter.Transform._write (/aternos/nodejs/hypnos/node_modules/readable-stream/lib/_stream_transform.js:164:83)
    at doWrite (/aternos/nodejs/hypnos/node_modules/readable-stream/lib/_stream_writable.js:409:139)
    at writeOrBuffer (/aternos/nodejs/hypnos/node_modules/readable-stream/lib/_stream_writable.js:398:5)
    at Splitter.Writable.write (/aternos/nodejs/hypnos/node_modules/readable-stream/lib/_stream_writable.js:307:11) {
  code: 'ERR_OUT_OF_RANGE'
}
```

This shouldn't happen when the `hideErrors` option is enabled. I've passed the `hideErrors` option from the `Client` to the `Splitter` and it now only throws the errors when `hideErrors` is disabled.