### PR TITLE
Add motd as MessageBuilder object

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,7 @@ automatically logged in and validated against mojang's auth.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"
- * chatMessageMotd : A json object off the chat message to use instead of `motd`. Can be build using [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) and calling .toJSON(). Not used with legacy pings.
+ * chatMessageMotd : A json object of the chat message to use instead of `motd`. Can be build using [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) and calling .toJSON(). Not used with legacy pings.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,7 @@ automatically logged in and validated against mojang's auth.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"
- * chatMessageMotd : A json object off the chat message to use instead of `motd`. See MessageBuilder in [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat). Not used with legacy pings.
+ * chatMessageMotd : A json object off the chat message to use instead of `motd`. Can be build using [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) and calling .toJSON(). Not used with legacy pings.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,7 @@ automatically logged in and validated against mojang's auth.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"
- * chatMessageMotd : A json object of the chat message to use instead of `motd`. Can be build using [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) and calling .toJSON(). Not used with legacy pings.
+ * motdMsg : A json object of the chat message to use instead of `motd`. Can be build using [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) and calling .toJSON(). Not used with legacy pings.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,7 @@ automatically logged in and validated against mojang's auth.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"
- * chatMessageMotd : A MessageBuilder instance from [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) to use instead of motd. Not used with legacy pings.
+ * chatMessageMotd : A json object off the chat message to use instead of `motd`. See MessageBuilder in [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat). Not used with legacy pings.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@ automatically logged in and validated against mojang's auth.
  * beforeLogin : allow customisation of client before the `success` packet is sent.
  It takes a function with argument client and should be synchronous for the server to wait for completion before continuing execution.
  * motd : default to "A Minecraft server"
+ * chatMessageMotd : A MessageBuilder instance from [prismarine-chat](https://github.com/PrismarineJS/prismarine-chat) to use instead of motd. Not used with legacy pings.
  * maxPlayers : default to 20
  * keepAlive : send keep alive packets : default to true
  * version : the version of the server, defaults to the latest version. Set version to `false` to enable dynamic cross version support.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node-fetch": "^2.6.1",
     "node-rsa": "^0.4.2",
     "prismarine-auth": "^1.1.0",
+    "prismarine-chat": "^1.6.1",
     "prismarine-nbt": "^2.0.0",
     "protodef": "^1.8.0",
     "readable-stream": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "node-fetch": "^2.6.1",
     "node-rsa": "^0.4.2",
     "prismarine-auth": "^1.1.0",
-    "prismarine-chat": "^1.6.1",
     "prismarine-nbt": "^2.0.0",
     "protodef": "^1.8.0",
     "readable-stream": "^3.0.6",

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -23,7 +23,7 @@ function createServer (options = {}) {
     version,
     favicon,
     customPackets,
-    chatMessageMotd // This is when you want to send formated motd's from ChatMessage instances
+    motdMsg // This is when you want to send formated motd's from ChatMessage instances
   } = options
 
   const maxPlayers = options['max-players'] !== undefined ? maxPlayersOld : maxPlayersNew
@@ -38,7 +38,7 @@ function createServer (options = {}) {
   const server = new Server(mcversion.minecraftVersion, customPackets, hideErrors)
   server.mcversion = mcversion
   server.motd = motd
-  server.chatMessageMotd = chatMessageMotd
+  server.motdMsg = motdMsg
   server.maxPlayers = maxPlayers
   server.playerCount = 0
   server.onlineModeExceptions = Object.create(null)

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -23,7 +23,7 @@ function createServer (options = {}) {
     version,
     favicon,
     customPackets,
-    chatMessageMotd = undefined // This is when you want to send formated motd's from ChatMessage instances
+    chatMessageMotd // This is when you want to send formated motd's from ChatMessage instances
   } = options
 
   const maxPlayers = options['max-players'] !== undefined ? maxPlayersOld : maxPlayersNew

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -22,7 +22,8 @@ function createServer (options = {}) {
     maxPlayers: maxPlayersNew = 20,
     version,
     favicon,
-    customPackets
+    customPackets,
+    chatMessageMotd = undefined // This is when you want to send formated motd's from ChatMessage instances
   } = options
 
   const maxPlayers = options['max-players'] !== undefined ? maxPlayersOld : maxPlayersNew
@@ -37,6 +38,7 @@ function createServer (options = {}) {
   const server = new Server(mcversion.minecraftVersion, customPackets, hideErrors)
   server.mcversion = mcversion
   server.motd = motd
+  server.chatMessageMotd = chatMessageMotd
   server.maxPlayers = maxPlayers
   server.playerCount = 0
   server.onlineModeExceptions = Object.create(null)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,6 @@ import { Socket } from 'net'
 import * as Stream from 'stream'
 import { Agent } from 'http'
 import { Transform } from "readable-stream";
-import type { MessageBuilder } from 'prismarine-chat'
 
 type PromiseLike = Promise<void> | void
 
@@ -137,7 +136,7 @@ declare module 'minecraft-protocol' {
 		playerCount: number
 		maxPlayers: number
 		motd: string
-		chatMessageMotd?: MessageBuilder
+		chatMessageMotd?: Object
 		favicon: string
 		close(): void
 		on(event: 'connection', handler: (client: ServerClient) => PromiseLike): this
@@ -163,7 +162,7 @@ declare module 'minecraft-protocol' {
 		beforePing?: (response: any, client: Client, callback?: (error: any, result: any) => any) => any
 		beforeLogin?: (client: Client) => void
 		motd?: string
-		chatMessageMotd?: MessageBuilder
+		chatMessageMotd?: Object
 		maxPlayers?: number
 		keepAlive?: boolean
 		version?: string | false

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ import { Socket } from 'net'
 import * as Stream from 'stream'
 import { Agent } from 'http'
 import { Transform } from "readable-stream";
-import type { ChatMessage } from 'prismarine-chat'
+import type { MessageBuilder } from 'prismarine-chat'
 
 type PromiseLike = Promise<void> | void
 
@@ -137,7 +137,7 @@ declare module 'minecraft-protocol' {
 		playerCount: number
 		maxPlayers: number
 		motd: string
-		chatMessageMotd?: ChatMessage
+		chatMessageMotd?: MessageBuilder
 		favicon: string
 		close(): void
 		on(event: 'connection', handler: (client: ServerClient) => PromiseLike): this
@@ -163,7 +163,7 @@ declare module 'minecraft-protocol' {
 		beforePing?: (response: any, client: Client, callback?: (error: any, result: any) => any) => any
 		beforeLogin?: (client: Client) => void
 		motd?: string
-		chatMessageMotd?: ChatMessage
+		chatMessageMotd?: MessageBuilder
 		maxPlayers?: number
 		keepAlive?: boolean
 		version?: string | false

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -136,7 +136,7 @@ declare module 'minecraft-protocol' {
 		playerCount: number
 		maxPlayers: number
 		motd: string
-		chatMessageMotd?: Object
+		motdMsg?: Object
 		favicon: string
 		close(): void
 		on(event: 'connection', handler: (client: ServerClient) => PromiseLike): this
@@ -162,7 +162,7 @@ declare module 'minecraft-protocol' {
 		beforePing?: (response: any, client: Client, callback?: (error: any, result: any) => any) => any
 		beforeLogin?: (client: Client) => void
 		motd?: string
-		chatMessageMotd?: Object
+		motdMsg?: Object
 		maxPlayers?: number
 		keepAlive?: boolean
 		version?: string | false

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ import { Socket } from 'net'
 import * as Stream from 'stream'
 import { Agent } from 'http'
 import { Transform } from "readable-stream";
+import type { ChatMessage } from 'prismarine-chat'
 
 type PromiseLike = Promise<void> | void
 
@@ -136,6 +137,7 @@ declare module 'minecraft-protocol' {
 		playerCount: number
 		maxPlayers: number
 		motd: string
+		chatMessageMotd?: ChatMessage
 		favicon: string
 		close(): void
 		on(event: 'connection', handler: (client: ServerClient) => PromiseLike): this
@@ -161,6 +163,7 @@ declare module 'minecraft-protocol' {
 		beforePing?: (response: any, client: Client, callback?: (error: any, result: any) => any) => any
 		beforeLogin?: (client: Client) => void
 		motd?: string
+		chatMessageMotd?: ChatMessage
 		maxPlayers?: number
 		keepAlive?: boolean
 		version?: string | false

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -23,7 +23,7 @@ module.exports = function (client, server, { beforePing = null, version }) {
         online: server.playerCount,
         sample: []
       },
-      description: server.chatMessageMotd ?? { text: server.motd },
+      description: server.motdMsg ?? { text: server.motd },
       favicon: server.favicon
     }
 

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -16,7 +16,6 @@ module.exports = function (client, server, { beforePing = null, version }) {
           protocol: server.mcversion.version
         }
 
-    const description = server.chatMessageMotd ?? { text: server.motd }
     const response = {
       version: responseVersion,
       players: {
@@ -24,7 +23,7 @@ module.exports = function (client, server, { beforePing = null, version }) {
         online: server.playerCount,
         sample: []
       },
-      description,
+      description: server.chatMessageMotd ?? { text: server.motd },
       favicon: server.favicon
     }
 

--- a/src/server/ping.js
+++ b/src/server/ping.js
@@ -16,6 +16,7 @@ module.exports = function (client, server, { beforePing = null, version }) {
           protocol: server.mcversion.version
         }
 
+    const description = server.chatMessageMotd ?? { text: server.motd }
     const response = {
       version: responseVersion,
       players: {
@@ -23,7 +24,7 @@ module.exports = function (client, server, { beforePing = null, version }) {
         online: server.playerCount,
         sample: []
       },
-      description: { text: server.motd },
+      description,
       favicon: server.favicon
     }
 

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -166,7 +166,7 @@ for (const supportedVersion of mc.supportedVersions) {
       const server = mc.createServer({
         'online-mode': false,
         motd: 'test1234',
-        chatMessageMotd: chatMotd,
+        motdMsg: chatMotd,
         'max-players': 120,
         version: version.minecraftVersion,
         port: PORT

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -157,10 +157,11 @@ for (const supportedVersion of mc.supportedVersions) {
       }
     })
     it('responds to ping requests', function (done) {
-      const { MessageBuilder } = require('prismarine-chat')(version.minecraftVersion)
-      const chatMotd = new MessageBuilder()
-      chatMotd.setBold(true).setText('Example chat mesasge')
-      chatMotd.addExtra(new MessageBuilder().setText('Red text').setColor('red'))
+      const chatMotd = { // Generated with prismarine-chat MessageBuilder on version 1.16 may change in the future
+        extra: [{ color: 'red', text: 'Red text' }],
+        bold: true,
+        text: 'Example chat mesasge'
+      }
 
       const server = mc.createServer({
         'online-mode': false,

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -157,6 +157,52 @@ for (const supportedVersion of mc.supportedVersions) {
       }
     })
     it('responds to ping requests', function (done) {
+      const { MessageBuilder } = require('prismarine-chat')(version.minecraftVersion)
+      const chatMotd = new MessageBuilder()
+      chatMotd.setBold(true).setText('Example chat mesasge')
+      chatMotd.addExtra(new MessageBuilder().setText('Red text').setColor('red'))
+
+      const server = mc.createServer({
+        'online-mode': false,
+        motd: 'test1234',
+        chatMessageMotd: chatMotd,
+        'max-players': 120,
+        version: version.minecraftVersion,
+        port: PORT
+      })
+      server.on('listening', function () {
+        mc.ping({
+          host: '127.0.0.1',
+          version: version.minecraftVersion,
+          port: PORT
+        }, function (err, results) {
+          if (err) return done(err)
+          assert.ok(results.latency >= 0)
+          assert.ok(results.latency <= 1000)
+          delete results.latency
+          assert.deepEqual(results, {
+            version: {
+              name: version.minecraftVersion,
+              protocol: version.version
+            },
+            players: {
+              max: 120,
+              online: 0,
+              sample: []
+            },
+            description: { 
+              with: [],
+              extra: [ { color: 'red', text: 'Red text' } ],
+              bold: true,
+              text: 'Example chat mesasge'
+            }
+          })
+          server.close()
+        })
+      })
+      server.on('close', done)
+    })
+    it('responds with chatMessage motd\'s', function (done) {
       const server = mc.createServer({
         'online-mode': false,
         motd: 'test1234',

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -191,7 +191,6 @@ for (const supportedVersion of mc.supportedVersions) {
               sample: []
             },
             description: { 
-              with: [],
               extra: [ { color: 'red', text: 'Red text' } ],
               bold: true,
               text: 'Example chat mesasge'


### PR DESCRIPTION
This will allow the api to send Formate messages as motd text. This is currently not possible as the configured motd text is embedded into a pre made message object.