### PR TITLE
Change client end reason when client times out

### DIFF
--- a/src/server/keepalive.js
+++ b/src/server/keepalive.js
@@ -14,7 +14,7 @@ module.exports = function (client, server, {
     // check if the last keepAlive was too long ago (kickTimeout)
     const elapsed = new Date() - lastKeepAlive
     if (elapsed > kickTimeout) {
-      client.end('KeepAliveTimeout')
+      client.end('Timed out')
       return
     }
     sendKeepAliveTime = new Date()

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -132,7 +132,7 @@ for (const supportedVersion of mc.supportedVersions) {
       let count = 2
       server.on('connection', function (client) {
         client.on('end', function (reason) {
-          assert.strictEqual(reason, 'KeepAliveTimeout')
+          assert.strictEqual(reason, 'Timed out')
           server.close()
         })
       })


### PR DESCRIPTION
Before, when the client doesn't send keepAlive packets, the server ends the connection with the client with the reason 'keepAliveTimeout'. It may be unclear for the user (who sees this text) what this means.

I'm creating a pull request to change this text to 'Timed out', the same text used by the client when the server doesn't send keepAlive packets.