### PR TITLE
add custom minecraft type `varlong` which aliases to varint

### DIFF
--- a/src/datatypes/compiler-minecraft.js
+++ b/src/datatypes/compiler-minecraft.js
@@ -3,6 +3,7 @@ const minecraft = require('./minecraft')
 
 module.exports = {
   Read: {
+    varlong: ['native', minecraft.varlong[0]],
     UUID: ['native', (buffer, offset) => {
       return {
         value: UUID.stringify(buffer.slice(offset, 16 + offset)),
@@ -44,6 +45,7 @@ module.exports = {
     }]
   },
   Write: {
+    varlong: ['native', minecraft.varlong[1]],
     UUID: ['native', (value, buffer, offset) => {
       const buf = UUID.parse(value)
       buf.copy(buffer, offset)
@@ -77,6 +79,7 @@ module.exports = {
     }]
   },
   SizeOf: {
+    varlong: ['native', minecraft.varlong[2]],
     UUID: ['native', 16],
     restBuffer: ['native', (value) => {
       return value.length

--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -3,7 +3,7 @@
 const nbt = require('prismarine-nbt')
 const UUID = require('uuid-1345')
 const zlib = require('zlib')
-const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint;
+const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 
 module.exports = {
   varlong: [readVarLong, writeVarLong, sizeOfVarLong],

--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -3,8 +3,10 @@
 const nbt = require('prismarine-nbt')
 const UUID = require('uuid-1345')
 const zlib = require('zlib')
+const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint;
 
 module.exports = {
+  varlong: [readVarLong, writeVarLong, sizeOfVarLong],
   UUID: [readUUID, writeUUID, 16],
   nbt: [readNbt, writeNbt, sizeOfNbt],
   optionalNbt: [readOptionalNbt, writeOptionalNbt, sizeOfOptionalNbt],
@@ -14,6 +16,18 @@ module.exports = {
   topBitSetTerminatedArray: [readTopBitSetTerminatedArray, writeTopBitSetTerminatedArray, sizeOfTopBitSetTerminatedArray]
 }
 const PartialReadError = require('protodef').utils.PartialReadError
+
+function readVarLong (buffer, offset) {
+  return readVarInt(buffer, offset)
+}
+
+function writeVarLong (value, buffer, offset) {
+  return writeVarInt(value, buffer, offset)
+}
+
+function sizeOfVarLong (value) {
+  return sizeOfVarInt(value)
+}
 
 function readUUID (buffer, offset) {
   if (offset + 16 > buffer.length) { throw new PartialReadError() }


### PR DESCRIPTION
the purpose is to mark fields which are actually `varlong`s in the minecraft protocol as such in [`minecraft-data`](https://github.com/PrismarineJS/minecraft-data) to allow for more accurate implementations in lower level languages in which the specific number type actually matters.