### PR TITLE
[1.19] fix tests and library session code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - master, Mc1.19
   pull_request:
     branches: 
-      - master
+      - master, Mc1.19
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master, Mc1.19
+      - master
   pull_request:
     branches: 
-      - master, Mc1.19
+      - master
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "endian-toggle": "^0.0.0",
     "lodash.get": "^4.1.2",
     "lodash.merge": "^4.3.0",
-    "minecraft-data": "^3.7.2",
+    "minecraft-data": "^3.8.0",
     "minecraft-folder-path": "^1.2.0",
     "node-fetch": "^2.6.1",
     "node-rsa": "^0.4.2",

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -49,7 +49,6 @@ module.exports = function (client, options) {
         const encryptedVerifyTokenBuffer = crypto.publicEncrypt({ key: pubKey, padding: crypto.constants.RSA_PKCS1_PADDING }, packet.verifyToken)
 
         if (mcData.supportFeature('signatureEncryption')) {
-          // 1.19+
           // todo: add signature encryption
           // starting 1.19.1 we will not be able to join
           // the default server configuration without it
@@ -61,7 +60,6 @@ module.exports = function (client, options) {
             }
           })
         } else {
-          // pre 1.19
           client.write('encryption_begin', {
             sharedSecret: encryptedSharedSecretBuffer,
             verifyToken: encryptedVerifyTokenBuffer

--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -42,13 +42,31 @@ module.exports = function (client, options) {
       }
 
       function sendEncryptionKeyResponse () {
+        const mcData = require('minecraft-data')(client.version)
+
         const pubKey = mcPubKeyToPem(packet.publicKey)
         const encryptedSharedSecretBuffer = crypto.publicEncrypt({ key: pubKey, padding: crypto.constants.RSA_PKCS1_PADDING }, sharedSecret)
         const encryptedVerifyTokenBuffer = crypto.publicEncrypt({ key: pubKey, padding: crypto.constants.RSA_PKCS1_PADDING }, packet.verifyToken)
-        client.write('encryption_begin', {
-          sharedSecret: encryptedSharedSecretBuffer,
-          verifyToken: encryptedVerifyTokenBuffer
-        })
+
+        if (mcData.supportFeature('signatureEncryption')) {
+          // 1.19+
+          // todo: add signature encryption
+          // starting 1.19.1 we will not be able to join
+          // the default server configuration without it
+          client.write('encryption_begin', {
+            sharedSecret: encryptedSharedSecretBuffer,
+            hasVerifyToken: true,
+            crypto: {
+              verifyToken: encryptedVerifyTokenBuffer
+            }
+          })
+        } else {
+          // pre 1.19
+          client.write('encryption_begin', {
+            sharedSecret: encryptedSharedSecretBuffer,
+            verifyToken: encryptedVerifyTokenBuffer
+          })
+        }
         client.setEncryption(sharedSecret)
       }
     }

--- a/src/client/setProtocol.js
+++ b/src/client/setProtocol.js
@@ -27,6 +27,7 @@ module.exports = function (client, options) {
       client.write('login_start', {
         username: client.username
       })
+      // TODO: add signature option
     }
   }
 }

--- a/src/server/login.js
+++ b/src/server/login.js
@@ -55,18 +55,50 @@ module.exports = function (client, server, options) {
   }
 
   function onEncryptionKeyResponse (packet) {
+    const mcData = require('minecraft-data')(client.version)
+
+    let packetVerifyToken
+    let signature
+
+    if (mcData.supportFeature('signatureEncryption')) {
+      // 1.19+
+      if (packet.hasVerifyToken) {
+        packetVerifyToken = packet.crypto.verifyToken
+      } else {
+        signature = packet.crypto
+      }
+    } else {
+      // pre 1.19
+      packetVerifyToken = packet.verifyToken
+    }
+
     let sharedSecret
-    try {
-      const verifyToken = crypto.privateDecrypt({ key: server.serverKey.exportKey(), padding: crypto.constants.RSA_PKCS1_PADDING }, packet.verifyToken)
-      if (!bufferEqual(client.verifyToken, verifyToken)) {
+
+    if (packetVerifyToken) {
+      try {
+        const verifyToken = crypto.privateDecrypt({
+          key: server.serverKey.exportKey(),
+          padding: crypto.constants.RSA_PKCS1_PADDING
+        }, packetVerifyToken)
+        if (!bufferEqual(client.verifyToken, verifyToken)) {
+          client.end('DidNotEncryptVerifyTokenProperly')
+          return
+        }
+        sharedSecret = crypto.privateDecrypt({
+          key: server.serverKey.exportKey(),
+          padding: crypto.constants.RSA_PKCS1_PADDING
+        }, packet.sharedSecret)
+      } catch (e) {
         client.end('DidNotEncryptVerifyTokenProperly')
         return
       }
-      sharedSecret = crypto.privateDecrypt({ key: server.serverKey.exportKey(), padding: crypto.constants.RSA_PKCS1_PADDING }, packet.sharedSecret)
-    } catch (e) {
-      client.end('DidNotEncryptVerifyTokenProperly')
+    } else {
+      // todo: signature encryption
+      client.end('signature encryption not implemented')
+      console.error(signature)
       return
     }
+
     client.setEncryption(sharedSecret)
 
     const isException = !!server.onlineModeExceptions[client.username.toLowerCase()]
@@ -114,7 +146,12 @@ module.exports = function (client, server, options) {
       client.write('compress', { threshold: 256 }) // Default threshold is 256
       client.compressionThreshold = 256
     }
-    client.write('success', { uuid: client.uuid, username: client.username })
+    client.write('success', {
+      uuid: client.uuid,
+      username: client.username,
+      properties: []
+    })
+    // TODO: find out what properties are on 'success' packet
     client.state = states.PLAY
 
     clearTimeout(loginKickTimer)

--- a/src/server/login.js
+++ b/src/server/login.js
@@ -61,14 +61,12 @@ module.exports = function (client, server, options) {
     let signature
 
     if (mcData.supportFeature('signatureEncryption')) {
-      // 1.19+
       if (packet.hasVerifyToken) {
         packetVerifyToken = packet.crypto.verifyToken
       } else {
         signature = packet.crypto
       }
     } else {
-      // pre 1.19
       packetVerifyToken = packet.verifyToken
     }
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -7,7 +7,8 @@ const states = mc.states
 
 const testDataWrite = [
   { name: 'keep_alive', params: { keepAliveId: 957759560 } },
-  { name: 'chat', params: { message: '<Bob> Hello World!' } },
+  // TODO: 1.19+ `chat` -> `player_chat` feature toggle
+  // { name: 'chat', params: { message: '<Bob> Hello World!' } },
   { name: 'position_look', params: { x: 6.5, y: 65.62, stance: 67.24, z: 7.5, yaw: 0, pitch: 0, onGround: true } }
   // TODO: add more packets for better quality data
 ]

--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -149,7 +149,6 @@ for (const supportedVersion of mc.supportedVersions) {
 
         client.on('player_chat', function (packet) {
           chatCount += 1
-          console.log('player_chat', packet)
 
           const sender = JSON.parse(packet.senderName)
           const chatContent = JSON.parse(packet.signedChatContent)

--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -120,7 +120,7 @@ for (const supportedVersion of mc.supportedVersions) {
           chat(client, 'hello everyone; I have logged in.')
         })
 
-        // pre 1.19
+        // pre 1.19 named 'chat'
 
         client.on('chat', function (packet) {
           chatCount += 1
@@ -145,7 +145,7 @@ for (const supportedVersion of mc.supportedVersions) {
           resolve()
         })
 
-        // 1.19+
+        // 1.19+ named 'player_chat'
 
         client.on('player_chat', function (packet) {
           chatCount += 1

--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -150,7 +150,7 @@ for (const supportedVersion of mc.supportedVersions) {
         client.on('player_chat', function (packet) {
           chatCount += 1
           console.log('player_chat', packet)
-          // assert.strictEqual(packet.type, )
+
           const sender = JSON.parse(packet.senderName)
           const chatContent = JSON.parse(packet.signedChatContent)
 
@@ -192,12 +192,6 @@ for (const supportedVersion of mc.supportedVersions) {
 
           resolve()
         })
-        // client.on('system_chat', function (packet) {
-        //   chatCount++
-        //   console.log('system_chat', packet)
-        //   // const content = JSON.parse(packet.content)
-        //   maybeFinish()
-        // })
 
         function resolve () {
           assert.ok(chatCount <= 2)

--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -12,7 +12,7 @@ const Wrap = require('minecraft-wrap').Wrap
 
 const download = util.promisify(require('minecraft-wrap').download)
 
-const { getPort } = require('./common/util')
+const { getPort, chat } = require('./common/util')
 
 for (const supportedVersion of mc.supportedVersions) {
   let PORT = null
@@ -104,6 +104,9 @@ for (const supportedVersion of mc.supportedVersions) {
         })
         client.on('error', err => done(err))
         const lineListener = function (line) {
+          // 1.19+ also prints Server like a player
+          if (line.match(/\[Server thread\/INFO\]: <Server> .*/)) return
+
           const match = line.match(/\[Server thread\/INFO\]: <(.+?)> (.+)/)
           if (!match) return
           assert.strictEqual(match[1], 'Player')
@@ -114,13 +117,13 @@ for (const supportedVersion of mc.supportedVersions) {
         let chatCount = 0
         client.on('login', function (packet) {
           assert.strictEqual(packet.gameMode, 0)
-          client.write('chat', {
-            message: 'hello everyone; I have logged in.'
-          })
+          chat(client, 'hello everyone; I have logged in.')
         })
+
+        // pre 1.19
+
         client.on('chat', function (packet) {
           chatCount += 1
-          assert.ok(chatCount <= 2)
           const message = JSON.parse(packet.message)
           if (chatCount === 1) {
             assert.strictEqual(message.translate, 'chat.type.text')
@@ -138,11 +141,72 @@ for (const supportedVersion of mc.supportedVersions) {
                   ? message.with[1].extra[0].text
                   : message.with[1].extra[0])
               : message.with[1].text, 'hello')
+          }
+          resolve()
+        })
+
+        // 1.19+
+
+        client.on('player_chat', function (packet) {
+          chatCount += 1
+          console.log('player_chat', packet)
+          // assert.strictEqual(packet.type, )
+          const sender = JSON.parse(packet.senderName)
+          const chatContent = JSON.parse(packet.signedChatContent)
+
+          switch (chatCount) {
+            case 1:
+              assert.deepStrictEqual(sender, {
+                insertion: 'Player',
+                clickEvent: {
+                  action: 'suggest_command',
+                  value: '/tell Player '
+                },
+                hoverEvent: {
+                  action: 'show_entity',
+                  contents: {
+                    type: 'minecraft:player',
+                    id: 'a01e3843-e521-3998-958a-f459800e4d11',
+                    name: {
+                      text: 'Player'
+                    }
+                  }
+                },
+                text: 'Player'
+              })
+              assert.deepStrictEqual(chatContent, {
+                text: 'hello everyone; I have logged in.'
+              })
+              assert.strictEqual(packet.type, 0)
+              break
+
+            case 2:
+              assert.deepStrictEqual(sender, {
+                text: 'Server'
+              })
+              assert.deepStrictEqual(chatContent, {
+                text: 'hello'
+              })
+              assert.strictEqual(packet.type, 3)
+          }
+
+          resolve()
+        })
+        // client.on('system_chat', function (packet) {
+        //   chatCount++
+        //   console.log('system_chat', packet)
+        //   // const content = JSON.parse(packet.content)
+        //   maybeFinish()
+        // })
+
+        function resolve () {
+          assert.ok(chatCount <= 2)
+          if (chatCount === 2) {
             wrap.removeListener('line', lineListener)
             client.end()
             done()
           }
-        })
+        }
       })
 
       it('does not crash for ' + SURVIVE_TIME + 'ms', function (done) {
@@ -153,9 +217,7 @@ for (const supportedVersion of mc.supportedVersions) {
         })
         client.on('error', err => done(err))
         client.on('login', function () {
-          client.write('chat', {
-            message: 'hello everyone; I have logged in.'
-          })
+          chat(client, 'hello everyone; I have logged in.')
           setTimeout(function () {
             client.end()
             done()
@@ -231,9 +293,7 @@ for (const supportedVersion of mc.supportedVersions) {
           assert.strictEqual(packet.difficulty, 1)
           assert.strictEqual(packet.dimension, 0)
           assert.strictEqual(packet.gameMode, 0)
-          client.write('chat', {
-            message: 'hello everyone; I have logged in.'
-          })
+          chat(client, 'hello everyone; I have logged in.')
         })
         let chatCount = 0
         client.on('chat', function (packet) {

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -17,7 +17,6 @@ function serverchat (client, message) {
 function makeBroadcast (version, message) {
   const mcData = require('minecraft-data')(version)
   if (mcData.supportFeature('signedChat')) {
-    // 1.19+
     return ['player_chat', {
       signedChatContent: JSON.stringify({ text: message }),
       unsignedChatContent: undefined,
@@ -29,7 +28,6 @@ function makeBroadcast (version, message) {
       signature: []
     }]
   } else {
-    // pre 1.19
     return ['chat', {
       message: JSON.stringify({ text: message }),
       position: 0,
@@ -41,8 +39,6 @@ function makeBroadcast (version, message) {
 function chat (client, message) {
   const mcData = require('minecraft-data')(client.version)
   if (mcData.supportFeature('signedChat')) {
-    // 1.19+
-
     client.write('chat_message', {
       message,
       timestamp: Date.now() * 1000,
@@ -51,8 +47,6 @@ function chat (client, message) {
       signedPreview: true
     })
   } else {
-    // pre 1.19
-
     client.write('chat', {
       message
     })
@@ -62,15 +56,11 @@ function chat (client, message) {
 function clientXChat (x, client, fn) {
   const mcData = require('minecraft-data')(client.version)
   if (mcData.supportFeature('signedChat')) {
-    // 1.19+
-
     x.bind(client)('player_chat', (packet) => {
       const message = packet.unsignedChatContent || packet.signedChatContent
       fn(message)
     })
   } else {
-    // pre 1.19
-
     x.bind(client)('chat', (packet) => {
       const message = packet.message
       fn(message)
@@ -81,15 +71,11 @@ function clientXChat (x, client, fn) {
 function serverXChat (x, server, fn) {
   const mcData = require('minecraft-data')(server.version)
   if (mcData.supportFeature('signedChat')) {
-    // 1.19+
-
     x.bind(server)('chat_message', (packet) => {
       const message = packet.message
       fn(message)
     })
   } else {
-    // pre 1.19
-
     x.bind(server)('chat', (packet) => {
       const message = packet.message
       fn(message)
@@ -107,13 +93,9 @@ async function OnceChatPromise (client) {
   const mcData = require('minecraft-data')(client.version)
   const { once } = require('events')
   if (mcData.supportFeature('signedChat')) {
-    // 1.19+
-
     const [packet] = await once(client, 'player_chat')
     return packet.unsignedChatContent || packet.signedChatContent
   } else {
-    // pre 1.19
-
     const [packet] = await once(client, 'chat')
     return packet.message
   }

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -9,4 +9,116 @@ const getPort = () => new Promise(resolve => {
   })
 })
 
-module.exports = { getPort }
+function serverchat (client, message) {
+  const [event, data] = makeBroadcast(client.version, message)
+  client.write(event, data)
+}
+
+function makeBroadcast (version, message) {
+  const mcData = require('minecraft-data')(version)
+  if (mcData.supportFeature('signedChat')) {
+    // 1.19+
+    return ['player_chat', {
+      signedChatContent: JSON.stringify({ text: message }),
+      unsignedChatContent: undefined,
+      type: 0,
+      senderUuid: '0',
+      senderName: 'Server',
+      timestamp: Date.now() * 1000,
+      salt: 0,
+      signature: []
+    }]
+  } else {
+    // pre 1.19
+    return ['chat', {
+      message: JSON.stringify({ text: message }),
+      position: 0,
+      sender: '0'
+    }]
+  }
+}
+
+function chat (client, message) {
+  const mcData = require('minecraft-data')(client.version)
+  if (mcData.supportFeature('signedChat')) {
+    // 1.19+
+
+    client.write('chat_message', {
+      message,
+      timestamp: Date.now() * 1000,
+      salt: 0,
+      signature: [],
+      signedPreview: true
+    })
+  } else {
+    // pre 1.19
+
+    client.write('chat', {
+      message
+    })
+  }
+}
+
+function clientXChat (x, client, fn) {
+  const mcData = require('minecraft-data')(client.version)
+  if (!mcData.supportFeature('signedChat')) {
+    // 1.19+
+
+    x.bind(client)('player_chat', (packet) => {
+      console.log('player_chat triggered')
+      const message = packet.unsignedChatContent || packet.signedChatContent
+      fn(message)
+    })
+  } else {
+    // pre 1.19
+
+    x.bind(client)('chat', (packet) => {
+      const message = packet.message
+      fn(message)
+    })
+  }
+}
+
+function serverXChat (x, server, fn) {
+  const mcData = require('minecraft-data')(server.version)
+  if (mcData.supportFeature('signedChat')) {
+    // 1.19+
+
+    x.bind(server)('chat_message', (packet) => {
+      console.log('chat_message triggered:', packet)
+      const message = packet.message
+      fn(message)
+    })
+  } else {
+    // pre 1.19
+
+    x.bind(server)('chat', (packet) => {
+      const message = packet.message
+      fn(message)
+    })
+  }
+}
+
+function OnceChat (client, fn) {
+  clientXChat(client.once, client, fn)
+}
+function OnChat (client, fn) {
+  clientXChat(client.on, client, fn)
+}
+async function OnceChatPromise (client) {
+  const mcData = require('minecraft-data')(client.version)
+  const { once } = require('events')
+  if (mcData.supportFeature('signedChat')) {
+    // 1.19+
+
+    const [packet] = await once(client, 'player_chat')
+    return packet.unsignedChatContent || packet.signedChatContent
+  } else {
+    // pre 1.19
+
+    const packet = await once(client, 'chat')
+    return packet.message
+  }
+}
+
+module.exports = { getPort, serverchat, makeBroadcast, chat, OnceChat, OnceChatPromise, OnChat, clientXChat, serverXChat }

--- a/test/common/util.js
+++ b/test/common/util.js
@@ -61,11 +61,10 @@ function chat (client, message) {
 
 function clientXChat (x, client, fn) {
   const mcData = require('minecraft-data')(client.version)
-  if (!mcData.supportFeature('signedChat')) {
+  if (mcData.supportFeature('signedChat')) {
     // 1.19+
 
     x.bind(client)('player_chat', (packet) => {
-      console.log('player_chat triggered')
       const message = packet.unsignedChatContent || packet.signedChatContent
       fn(message)
     })
@@ -85,7 +84,6 @@ function serverXChat (x, server, fn) {
     // 1.19+
 
     x.bind(server)('chat_message', (packet) => {
-      console.log('chat_message triggered:', packet)
       const message = packet.message
       fn(message)
     })
@@ -116,7 +114,7 @@ async function OnceChatPromise (client) {
   } else {
     // pre 1.19
 
-    const packet = await once(client, 'chat')
+    const [packet] = await once(client, 'chat')
     return packet.message
   }
 }

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -176,7 +176,30 @@ const values = {
   tags: [{ tagName: 'hi', entries: [1, 2, 3, 4, 5] }],
   ingredient: [slotValue],
   particleData: null,
-  chunkBlockEntity: { x: 10, y: 11, z: 12, type: 25 }
+  chunkBlockEntity: { x: 10, y: 11, z: 12, type: 25 },
+  command_node: {
+    flags: {
+      has_custom_suggestions: 1,
+      has_redirect_node: 1,
+      has_command: 1,
+      command_node_type: 2
+    },
+    children: [23, 29],
+    redirectNode: 83,
+    extraNodeData: {
+      name: 'command_node name',
+      parser: 'brigadier:double',
+      properties: {
+        flags: {
+          max_present: 1,
+          min_present: 1
+        },
+        min: -5.0,
+        max: 256.0
+      },
+      suggestionType: 'minecraft:summonable_entities'
+    }
+  }
 }
 
 function getValue (_type, packet) {

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -40,6 +40,7 @@ const values = {
   i16: -123,
   u16: 123,
   varint: 1,
+  varlong: -20,
   i8: -10,
   u8: 8,
   string: 'hi hi this is my client string',


### PR DESCRIPTION
blocked by [mcd 1.19 features pr](https://github.com/PrismarineJS/minecraft-data/pull/599)

- tests now work again with the new chat packet names
- added todo's in places where further work is needed like
  - missing signature encryption
  - adding version check for benchmark test chat packet
- adds varlong and command_node packetTest types