### PR TITLE
Fix unhandled promise rejection on ms auth

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -43,7 +43,7 @@ function createClient (options) {
         auth(client, options)
         break
       case 'microsoft':
-        microsoftAuth.authenticate(client, options)
+        microsoftAuth.authenticate(client, options).catch((err) => client.emit('error', err))
         break
       case 'offline':
       default:


### PR DESCRIPTION
The authenticate function that does ms auth returns a promise that can reject on error. If this occurs in your code the node process will exit due to an unhandledRejection error.
This pull requests fixes this and instead emits a error event on the client.