### PR TITLE
Provide interface for using not at all supported alternative accounts.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,7 @@ Returns a `Client` instance and perform login.
 `options` is an object containing the properties :
  * username
  * port : default to 25565
- * auth : the type of account to use, either `microsoft`, `mojang`, or `offline`. default to 'offline'
+ * auth : the type of account to use, either `microsoft`, `mojang`, `offline` or `function (client, options) => void`. defaults to 'offline'.
  * password : can be omitted
    * (microsoft account) leave this blank to use device code auth. If you provide
    a password, we try to do username and password auth, but this does not always work.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,20 +1,27 @@
-## FAQ
+# FAQ
 
 This Frequently Asked Question document is meant to help people for the most common things.
 
-### How to hide errors ?
+## How to hide errors ?
 
 Use `hideErrors: true` in createClient options
 You may also choose to add these listeners :
+
 ```js
 client.on('error', () => {})
 client.on('end', () => {})
 ```
 
-### How can I make a proxy with this ?
+## How can I make a proxy with this ?
 
-* Check out our WIP proxy lib https://github.com/PrismarineJS/prismarine-proxy
-* See this example https://github.com/PrismarineJS/node-minecraft-protocol/tree/master/examples/proxy
-* Read this issue https://github.com/PrismarineJS/node-minecraft-protocol/issues/712
-* check out https://github.com/Heath123/pakkit
-* Check out this app https://github.com/wvffle/minecraft-packet-debugger
+* Check out our WIP proxy lib <https://github.com/PrismarineJS/prismarine-proxy>
+* See this example <https://github.com/PrismarineJS/node-minecraft-protocol/tree/master/examples/proxy>
+* Read this issue <https://github.com/PrismarineJS/node-minecraft-protocol/issues/712>
+* check out <https://github.com/Heath123/pakkit>
+* Check out this app <https://github.com/wvffle/minecraft-packet-debugger>
+
+## Can you support alternative auth methods?
+
+Supporting alternative authentcation methods has been a long standing issue with Prismarine for awhile. We do add support for using your own custom authentication method by providing a function to the `options.auth` property. In order to keep the legitimacy of the project, and to prevent bad attention from Mojang, we will not be supporting any custom authentication methods in the official repositories.
+
+It is up to the end user to support and maintain the authentication protocol if this is used as support in many of the official channels will be limited.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,3 +25,5 @@ client.on('end', () => {})
 Supporting alternative authentcation methods has been a long standing issue with Prismarine for awhile. We do add support for using your own custom authentication method by providing a function to the `options.auth` property. In order to keep the legitimacy of the project, and to prevent bad attention from Mojang, we will not be supporting any custom authentication methods in the official repositories.
 
 It is up to the end user to support and maintain the authentication protocol if this is used as support in many of the official channels will be limited.
+
+If you still wish to proceed, please make sure to throughly read and attempt to understand all implementations of the authentcation you wish to implement. Using an non-official authentication server can make you vulnerable to all different kinds of attacks which are not limited to insecure and/or malicious code! We will not be held responsible for anything you mess up.

--- a/examples/client_custom_auth/client_custom_auth.js
+++ b/examples/client_custom_auth/client_custom_auth.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const mc = require('minecraft-protocol')
+
+const [, , host, port, username, password] = process.argv
+if (!userOrEmail) {
+    console.log('Usage : node client_custom_auth.js <host> <port> <username/email> [<password>]')
+    process.exit(1)
+}
+
+const client = mc.createClient({
+    host, port: parseInt(port),
+    username: userOrEmail,
+    password: password,
+    sessionServer: '', // URL to your session server proxy that changes the expected result of mojang's seession server to mcleaks expected.
+    // For more information: https://github.com/PrismarineJS/node-yggdrasil/blob/master/src/Server.js#L19
+    auth: async((client, options) => {
+        // Using mcleaks.net as an example.
+        const token = options.password;
+        const redeemToken = await fetch(`https://auth.mcleaks.net/v1/redeem`, {
+            method: 'post',
+            body: JSON.stringify({ token }),
+            headers: { 'Content-Type': 'application/json' }
+        })
+        const data = await redeemToken.json();
+        if (!data.success) return console.log(`Something bad happened when trying to redeem this token.`);
+
+        client.username = data.result.mcname
+        options.accessToken = data.result.session
+        return options.connect(client)
+    })
+})
+
+client.on('connect', function () {
+    console.info('connected')
+})
+client.on('disconnect', function (packet) {
+    console.log('disconnected: ' + packet.reason)
+})
+client.on('chat', function (packet) {
+    const jsonMsg = JSON.parse(packet.message)
+    if (jsonMsg.translate === 'chat.type.announcement' || jsonMsg.translate === 'chat.type.text') {
+        const username = jsonMsg.with[0].text
+        const msg = jsonMsg.with[1]
+        if (username === client.username) return
+        client.write('chat', { message: msg })
+    }
+})

--- a/examples/client_custom_auth/client_custom_auth.js
+++ b/examples/client_custom_auth/client_custom_auth.js
@@ -1,48 +1,50 @@
 'use strict'
 
 const mc = require('minecraft-protocol')
+const fetch = require('node-fetch')
 
 const [, , host, port, username, password] = process.argv
-if (!userOrEmail) {
-    console.log('Usage : node client_custom_auth.js <host> <port> <username/email> [<password>]')
-    process.exit(1)
+if (!username || !password) {
+  console.log('Usage : node client_custom_auth.js <host> <port> <username/email> [<password>]')
+  process.exit(1)
 }
 
 const client = mc.createClient({
-    host, port: parseInt(port),
-    username: userOrEmail,
-    password: password,
-    sessionServer: '', // URL to your session server proxy that changes the expected result of mojang's seession server to mcleaks expected.
-    // For more information: https://github.com/PrismarineJS/node-yggdrasil/blob/master/src/Server.js#L19
-    auth: async((client, options) => {
-        // Using mcleaks.net as an example.
-        const token = options.password;
-        const redeemToken = await fetch(`https://auth.mcleaks.net/v1/redeem`, {
-            method: 'post',
-            body: JSON.stringify({ token }),
-            headers: { 'Content-Type': 'application/json' }
-        })
-        const data = await redeemToken.json();
-        if (!data.success) return console.log(`Something bad happened when trying to redeem this token.`);
-
-        client.username = data.result.mcname
-        options.accessToken = data.result.session
-        return options.connect(client)
+  host,
+  port: parseInt(port),
+  username: username,
+  password: password,
+  sessionServer: '', // URL to your session server proxy that changes the expected result of mojang's seession server to mcleaks expected.
+  // For more information: https://github.com/PrismarineJS/node-yggdrasil/blob/master/src/Server.js#L19
+  auth: async (client, options) => {
+    // Using mcleaks.net as an example.
+    const token = options.password
+    const redeemToken = await fetch('https://auth.mcleaks.net/v1/redeem', {
+      method: 'post',
+      body: JSON.stringify({ token }),
+      headers: { 'Content-Type': 'application/json' }
     })
+    const data = await redeemToken.json()
+    if (!data.success) return console.log('Something bad happened when trying to redeem this token.')
+
+    client.username = data.result.mcname
+    options.accessToken = data.result.session
+    return options.connect(client)
+  }
 })
 
 client.on('connect', function () {
-    console.info('connected')
+  console.info('connected')
 })
 client.on('disconnect', function (packet) {
-    console.log('disconnected: ' + packet.reason)
+  console.log('disconnected: ' + packet.reason)
 })
 client.on('chat', function (packet) {
-    const jsonMsg = JSON.parse(packet.message)
-    if (jsonMsg.translate === 'chat.type.announcement' || jsonMsg.translate === 'chat.type.text') {
-        const username = jsonMsg.with[0].text
-        const msg = jsonMsg.with[1]
-        if (username === client.username) return
-        client.write('chat', { message: msg })
-    }
+  const jsonMsg = JSON.parse(packet.message)
+  if (jsonMsg.translate === 'chat.type.announcement' || jsonMsg.translate === 'chat.type.text') {
+    const username = jsonMsg.with[0].text
+    const msg = jsonMsg.with[1]
+    if (username === client.username) return
+    client.write('chat', { message: msg })
+  }
 })

--- a/examples/client_custom_auth/client_custom_auth.js
+++ b/examples/client_custom_auth/client_custom_auth.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const mc = require('minecraft-protocol')
-const fetch = require('node-fetch')
 
 const [, , host, port, username, password] = process.argv
 if (!username || !password) {
@@ -17,18 +16,10 @@ const client = mc.createClient({
   sessionServer: '', // URL to your session server proxy that changes the expected result of mojang's seession server to mcleaks expected.
   // For more information: https://github.com/PrismarineJS/node-yggdrasil/blob/master/src/Server.js#L19
   auth: async (client, options) => {
-    // Using mcleaks.net as an example.
-    const token = options.password
-    const redeemToken = await fetch('https://auth.mcleaks.net/v1/redeem', {
-      method: 'post',
-      body: JSON.stringify({ token }),
-      headers: { 'Content-Type': 'application/json' }
-    })
-    const data = await redeemToken.json()
-    if (!data.success) return console.log('Something bad happened when trying to redeem this token.')
+    // handle custom authentication your way.
 
-    client.username = data.result.mcname
-    options.accessToken = data.result.session
+    // client.username = options.username
+    // options.accessToken =
     return options.connect(client)
   }
 })

--- a/examples/client_custom_auth/package.json
+++ b/examples/client_custom_auth/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "node-minecraft-protocol-example-client-custom-auth",
+  "version": "0.0.0",
+  "description": "A node-minecraft-protocol example",
+  "main": "client_custom_auth.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -34,6 +34,9 @@ function createClient (options) {
   const client = new Client(false, version.minecraftVersion, options.customPackets, hideErrors)
 
   tcpDns(client, options)
+  if (options.auth instanceof Function) {
+      options.auth(client, options)
+  } else {
   switch (options.auth) {
     case 'mojang':
       console.warn('[deprecated] mojang auth servers no longer accept mojang accounts to login. convert your account.\nhttps://help.minecraft.net/hc/en-us/articles/4403181904525-How-to-Migrate-Your-Mojang-Account-to-a-Microsoft-Account')
@@ -47,6 +50,7 @@ function createClient (options) {
       client.username = options.username
       options.connect(client)
       break
+    }
   }
   if (options.version === false) autoVersion(client, options)
   setProtocol(client, options)

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -35,21 +35,21 @@ function createClient (options) {
 
   tcpDns(client, options)
   if (options.auth instanceof Function) {
-      options.auth(client, options)
+    options.auth(client, options)
   } else {
-  switch (options.auth) {
-    case 'mojang':
-      console.warn('[deprecated] mojang auth servers no longer accept mojang accounts to login. convert your account.\nhttps://help.minecraft.net/hc/en-us/articles/4403181904525-How-to-Migrate-Your-Mojang-Account-to-a-Microsoft-Account')
-      auth(client, options)
-      break
-    case 'microsoft':
-      microsoftAuth.authenticate(client, options)
-      break
-    case 'offline':
-    default:
-      client.username = options.username
-      options.connect(client)
-      break
+    switch (options.auth) {
+      case 'mojang':
+        console.warn('[deprecated] mojang auth servers no longer accept mojang accounts to login. convert your account.\nhttps://help.minecraft.net/hc/en-us/articles/4403181904525-How-to-Migrate-Your-Mojang-Account-to-a-Microsoft-Account')
+        auth(client, options)
+        break
+      case 'microsoft':
+        microsoftAuth.authenticate(client, options)
+        break
+      case 'offline':
+      default:
+        client.username = options.username
+        options.connect(client)
+        break
     }
   }
   if (options.version === false) autoVersion(client, options)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,7 +101,7 @@ declare module 'minecraft-protocol' {
 	export interface ClientOptions {
 		username: string
 		port?: number
-		auth?: 'mojang' | 'microsoft' | 'offline'
+		auth?: 'mojang' | 'microsoft' | 'offline' | ((client: Client, options: ClientOptions) => void)
 		password?: string
 		host?: string
 		clientToken?: string


### PR DESCRIPTION
This provides an interface for the people desperate enough not wanting to spend money on a good game (that was until Microsoft got their grubby hands on it) to use alternative services to allow game play. I cannot heed this enough that using these alternative services may or may not get you into trouble. Do not hold me accountable.

This provides a solution for: https://github.com/PrismarineJS/mineflayer/issues/1116, https://github.com/PrismarineJS/mineflayer/issues/1331, https://github.com/PrismarineJS/mineflayer/issues/790, https://github.com/PrismarineJS/node-minecraft-protocol/issues/736, https://github.com/PrismarineJS/node-minecraft-protocol/issues/1025 and a bunch more that I am not bothering to look for.

This proposal is to check if the user has specified a function for `options.auth` rather than `mojang` | `microsoft`. If it is a function, we let that function handle setting the username, accessToken... making any related api calls. However, when it comes to joining, if they are not using the official session server, they will have to create a local proxy to convert the expected format that usually is sent to mojang's session server to their custom auth server.