### PR TITLE
Throw error on minecraft-data protocol version mismatch

### DIFF
--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -10,15 +10,20 @@ const states = require('../states')
 const merge = require('lodash.merge')
 const get = require('lodash.get')
 
+const minecraftData = require('minecraft-data')
 const protocols = {}
 
 function createProtocol (state, direction, version, customPackets, compiled = true) {
   const key = state + ';' + direction + ';' + version + (compiled ? ';c' : '')
   if (protocols[key]) { return protocols[key] }
 
-  const mcData = require('minecraft-data')(version)
+  const mcData = minecraftData(version)
+  const versionInfo = minecraftData.versionsByMinecraftVersion.pc[version]
   if (mcData === null) {
     throw new Error(`No data available for version ${version}`)
+  } else if (versionInfo && versionInfo.version !== mcData.version.version) {
+    // The protocol version returned by node-minecraft-data constructor does not match the data in minecraft-data's protocolVersions.json
+    throw new Error(`Do not have protocol data for protocol version ${versionInfo.version} (attempted to use ${mcData.version.version} data)`)
   }
 
   if (compiled) {


### PR DESCRIPTION
require('minecraft-data')('1.19.1') can redirect to require('minecraft-data')('1.19') (the major version) per node-minecraft-data constructor's version handling. This can cause issues if the protocol version changed between patch updates even on the same major, so throw error to prevent.