### PR TITLE
Fix breaking issues in 1.19.2

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -102,7 +102,7 @@ module.exports = function (client, options) {
     }
 
     // Chain integrity remains even if message is considered unverified due to expiry
-    const tsDelta = Date.now() - packet.timestamp
+    const tsDelta = BigInt(Date.now()) - packet.timestamp
     const expired = !packet.timestamp || tsDelta > messageExpireTime || tsDelta < 0
     const verified = updateAndValidateChat(packet.senderUuid, packet.previousSignature, packet.signature, hash.digest()) && !expired
     client.emit('playerChat', {

--- a/src/client/play.js
+++ b/src/client/play.js
@@ -19,7 +19,7 @@ module.exports = function (client, options) {
     client.username = packet.username
 
     if (mcData.supportFeature('signedChat')) {
-      if (!options.disableChatSigning && client.serverFeatures.enforcesSecureChat) {
+      if (options.disableChatSigning && client.serverFeatures.enforcesSecureChat) {
         throw new Error('"disableChatSigning" was enabled in client options, but server is enforcing secure chat')
       }
       signedChatPlugin(client, options)


### PR DESCRIPTION
1. Type mismatch between Date.now (type number) and packet.timestamp (type bigint) causes program to throw when attempting to send a chat message
2. (Assumably) typo in play.js means program throws when server enforces secure chat and client has chat signing enabled (and does not throw when client has chat signing disabled)