### PR TITLE
Fix chat previews not working

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,6 +32,7 @@ automatically logged in and validated against mojang's auth.
  * agent : a http agent that can be used to set proxy settings for yggdrasil authentication confirmation (see proxy-agent on npm)
  * validateChannelProtocol (optional) : whether or not to enable protocol validation for custom protocols using plugin channels for the connected clients. Defaults to true
  * enforceSecureProfile (optional) : Kick clients that do not have chat signing keys from Mojang (1.19+)
+ * generatePreview (optional) : Function to generate chat previews. Takes the raw message string and should return the message preview as a string.  (1.19-1.19.2)
 
 ## mc.Server(version,[customPackets])
 

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -206,7 +206,7 @@ module.exports = function (client, options) {
           hash.update(previousMessage.signature)
         }
 
-        if(!!preview) hash.update(preview);
+        if (preview) hash.update(preview)
         // Feed hash back into signing payload
         signer.update(hash.digest())
       }

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -9,6 +9,7 @@ function isFormatted (message) {
     for (const key in comp) {
       if (key !== 'text') return true
     }
+    if(comp.text && comp.text !== message) return true
     return false
   } catch {
     return false

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -158,7 +158,7 @@ module.exports = function (client, options) {
         message,
         timestamp: options.timestamp,
         salt: options.salt,
-        signature: client.profileKeys ? client.signMessage(options.preview || message, options.timestamp, options.salt) : Buffer.alloc(0),
+        signature: client.profileKeys ? client.signMessage(message, options.timestamp, options.salt, options.preview) : Buffer.alloc(0),
         signedPreview: options.didPreview,
         previousMessages: client._lastSeenMessages.map((e) => ({
           messageSender: e.sender,
@@ -185,7 +185,7 @@ module.exports = function (client, options) {
   })
 
   // Signing methods
-  client.signMessage = (message, timestamp, salt = 0) => {
+  client.signMessage = (message, timestamp, salt = 0, preview) => {
     if (!client.profileKeys) throw Error("Can't sign message without profile keys, please set valid auth mode")
 
     if (mcData.supportFeature('chainedChatWithHashing')) {
@@ -205,6 +205,8 @@ module.exports = function (client, options) {
           hash.update(concat('i8', 70, 'UUID', previousMessage.sender))
           hash.update(previousMessage.signature)
         }
+
+        if(!!preview) hash.update(preview);
         // Feed hash back into signing payload
         signer.update(hash.digest())
       }

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -201,12 +201,11 @@ module.exports = function (client, options) {
       } else {
         const hash = crypto.createHash('sha256')
         hash.update(concat('i64', salt, 'i64', timestamp / 1000n, 'pstring', message, 'i8', 70))
+        if (preview) hash.update(preview)
         for (const previousMessage of client._lastSeenMessages) {
           hash.update(concat('i8', 70, 'UUID', previousMessage.sender))
           hash.update(previousMessage.signature)
         }
-
-        if (preview) hash.update(preview)
         // Feed hash back into signing payload
         signer.update(hash.digest())
       }

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -9,7 +9,7 @@ function isFormatted (message) {
     for (const key in comp) {
       if (key !== 'text') return true
     }
-    if(comp.text && comp.text !== message) return true
+    if (comp.text && comp.text !== message) return true
     return false
   } catch {
     return false

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -2,6 +2,19 @@ const crypto = require('crypto')
 const concat = require('../transforms/binaryStream').concat
 const messageExpireTime = 420000 // 7 minutes (ms)
 
+function isFormatted (message) {
+  // This should match the ChatComponent.isDecorated function from Vanilla
+  try {
+    const comp = JSON.parse(message)
+    for (const key in comp) {
+      if (key !== 'text') return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
 module.exports = function (client, options) {
   const mcData = require('minecraft-data')(client.version)
   client._players = {}
@@ -179,7 +192,7 @@ module.exports = function (client, options) {
 
   client.on('chat_preview', (packet) => {
     if (pendingChatRequest && pendingChatRequest.id === packet.queryId) {
-      client._signedChat(pendingChatRequest.message, { ...pendingChatRequest.options, skipPreview: true, didPreview: true, preview: packet.message })
+      client._signedChat(pendingChatRequest.message, { ...pendingChatRequest.options, skipPreview: true, didPreview: true, preview: isFormatted(packet.message) ? packet.message : undefined })
       pendingChatRequest = null
     }
   })

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -158,7 +158,7 @@ module.exports = function (client, options) {
         message,
         timestamp: options.timestamp,
         salt: options.salt,
-        signature: client.profileKeys ? client.signMessage(message, options.timestamp, options.salt) : Buffer.alloc(0),
+        signature: client.profileKeys ? client.signMessage(options.preview || message, options.timestamp, options.salt) : Buffer.alloc(0),
         signedPreview: options.didPreview,
         previousMessages: client._lastSeenMessages.map((e) => ({
           messageSender: e.sender,
@@ -178,8 +178,8 @@ module.exports = function (client, options) {
   }
 
   client.on('chat_preview', (packet) => {
-    if (pendingChatRequest && pendingChatRequest.id === packet.query) {
-      client._signedChat(packet.message, { ...pendingChatRequest.options, skipPreview: true, didPreview: true })
+    if (pendingChatRequest && pendingChatRequest.id === packet.queryId) {
+      client._signedChat(pendingChatRequest.message, { ...pendingChatRequest.options, skipPreview: true, didPreview: true, preview: packet.message })
       pendingChatRequest = null
     }
   })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,7 +35,7 @@ declare module 'minecraft-protocol' {
 		registerChannel(name: string, typeDefinition: any, custom?: boolean): void
 		unregisterChannel(name: string): void
 		writeChannel(channel: any, params: any): void
-		signMessage(message: string, timestamp: BigInt, salt?: number): Buffer
+		signMessage(message: string, timestamp: BigInt, salt?: number, preview?: string): Buffer
 		verifyMessage(publicKey: Buffer | KeyObject, packet: object): boolean
 		reportPlayer(uuid: string, reason: 'FALSE_REPORTING' | 'HATE_SPEECH' | 'TERRORISM_OR_VIOLENT_EXTREMISM' | 'CHILD_SEXUAL_EXPLOITATION_OR_ABUSE' | 'IMMINENT_HARM' | 'NON_CONSENSUAL_INTIMATE_IMAGERY' | 'HARASSMENT_OR_BULLYING' | 'DEFAMATION_IMPERSONATION_FALSE_INFORMATION' | 'SELF_HARM_OR_SUICIDE' | 'ALCOHOL_TOBACCO_DRUGS', signatures: Buffer[], comment?: string)
 		on(event: 'error', listener: (error: Error) => PromiseLike): this

--- a/src/server/chat.js
+++ b/src/server/chat.js
@@ -42,6 +42,8 @@ module.exports = function (client, server, options) {
   const raise = (translatableError) => client.end(translatableError, JSON.stringify({ translate: translatableError }))
   const pending = new Pending()
 
+  if (options.generatePreview) options.generatePreview = message => message
+
   function validateMessageChain (packet) {
     try {
       validateLastMessages(pending, packet.previousMessages, packet.lastRejectedMessage)
@@ -92,6 +94,7 @@ module.exports = function (client, server, options) {
         // Player Chat
         const hash = crypto.createHash('sha256')
         hash.update(concat('i64', packet.salt, 'i64', packet.timestamp / 1000n, 'pstring', packet.message, 'i8', 70))
+        if (packet.signedPreview) hash.update(options.generatePreview(packet.message))
         for (const { messageSender, messageSignature } of packet.previousMessages) {
           hash.update(concat('i8', 70, 'UUID', messageSender))
           hash.update(messageSignature)

--- a/src/server/chat.js
+++ b/src/server/chat.js
@@ -42,7 +42,7 @@ module.exports = function (client, server, options) {
   const raise = (translatableError) => client.end(translatableError, JSON.stringify({ translate: translatableError }))
   const pending = new Pending()
 
-  if (options.generatePreview) options.generatePreview = message => message
+  if (!options.generatePreview) options.generatePreview = message => message
 
   function validateMessageChain (packet) {
     try {


### PR DESCRIPTION
- Chat preview packet handler now uses the correct name for fields from protocol definition (`packet.query` is now `packet.queryId`)
- Pass original message to `_signedChat` instead of previewed message
- Create message signature using previewed message