### PR TITLE
Update convenience chat events so higher-level clients can properly parse chat

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -268,6 +268,12 @@ Called when a chat message from another player arrives. The emitted object conta
 * senderTeam -- scoreboard team of the player (pre 1.19)
 * verified -- true if message is signed, false if not signed, undefined on versions prior to 1.19
 
+### `systemChat` event
+
+Called when a system chat message arrives. A system chat message is any message not sent by a player. The emitted object contains:
+* formattedMessage -- the chat message preformatted
+* positionid -- the chat type of the message. 1 for system chat and 2 for actionbar
+
 See the [chat example](https://github.com/PrismarineJS/node-minecraft-protocol/blob/master/examples/client_chat/client_chat.js#L1) for usage.
 
 ### per-packet events

--- a/docs/API.md
+++ b/docs/API.md
@@ -261,7 +261,8 @@ Called when an error occurs within the client. Takes an Error as parameter.
 
 Called when a chat message from another player arrives. The emitted object contains:
 * formattedMessage -- the chat message preformatted, if done on server side
-* message -- the chat message without formatting (for example no `<username> message` ; instead `message`), on version 1.19+
+* plainMessage -- the chat message without formatting (for example no `<username> message` ; instead `message`), on version 1.19+
+* unsignedContent -- unsigned formatted chat contents ; should only be present when the message is modified and server has chat previews disabled - only on version 1.19 - 1.19.2
 * type -- the message type - on 1.19, which format string to use to render message ; below, the place where the message is displayed (for example chat or action bar)
 * sender -- the UUID of the player sending the message
 * senderTeam -- scoreboard team of the player (pre 1.19)

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -113,7 +113,8 @@ module.exports = function (client, options) {
     const expired = !packet.timestamp || tsDelta > messageExpireTime || tsDelta < 0
     const verified = updateAndValidateChat(packet.senderUuid, packet.previousSignature, packet.signature, hash.digest()) && !expired
     client.emit('playerChat', {
-      message: packet.plainMessage || packet.unsignedChatContent,
+      plainMessage: packet.plainMessage,
+      unsignedMessage: packet.unsignedChatContent,
       formattedMessage: packet.formattedMessage,
       type: packet.type,
       sender: packet.senderUuid,

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -228,7 +228,7 @@ module.exports = function (client, options) {
   }
 
   client.verifyMessage = (pubKey, packet) => {
-    if (!mcData.supportFeature('chainedChatWithHashing')) { // 1.19.0
+    if (mcData.supportFeature('chainedChatWithHashing')) { // 1.19.1+
       // Verification handled internally in 1.19.1+ as previous messages must be stored to verify future messages
       throw new Error("Please listen to the 'playerChat' event instead to check message validity. client.verifyMessage is deprecated and only works on version 1.19.")
     }

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -69,6 +69,13 @@ module.exports = function (client, options) {
     }
   })
 
+  client.on('system_chat', (packet) => {
+    client.emit('systemChat', {
+      positionid: packet.isActionBar ? 2 : 1,
+      formattedMessage: packet.content
+    })
+  })
+
   client.on('message_header', (packet) => {
     updateAndValidateChat(packet.senderUuid, packet.previousSignature, packet.signature, packet.messageHash)
 

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -114,7 +114,7 @@ module.exports = function (client, options) {
     const verified = updateAndValidateChat(packet.senderUuid, packet.previousSignature, packet.signature, hash.digest()) && !expired
     client.emit('playerChat', {
       plainMessage: packet.plainMessage,
-      unsignedMessage: packet.unsignedChatContent,
+      unsignedContent: packet.unsignedChatContent,
       formattedMessage: packet.formattedMessage,
       type: packet.type,
       sender: packet.senderUuid,


### PR DESCRIPTION
- Emit systemChat event in all versions (not just versions before 1.19)
- Emit plainMessage and unsignedContent as a part of the playerChat event
- Fix client throwing when trying to verify messages in version 1.19