### PR TITLE
Fix chat not working on Velocity-powered servers

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -184,7 +184,7 @@ module.exports = function (client, options) {
 
   client._signedChat = (message, options = {}) => {
     options.timestamp = options.timestamp || BigInt(Date.now())
-    options.salt = options.salt || 0
+    options.salt = options.salt || 1n
 
     if (options.skipPreview || !client.serverFeatures.chatPreview) {
       client.write('chat_message', {


### PR DESCRIPTION
Velocity servers for some reason throw invalid signature if the provided salt is zero. This does not comply with the Vanilla specification so is technically an issue on their part. This PR will fix it, but it is ultimately not an issue with NMP