### PR TITLE
Add more fields to playerChat event

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -272,7 +272,7 @@ Called when a chat message from another player arrives. The emitted object conta
 * sender -- the UUID of the player sending the message
 * senderTeam -- scoreboard team of the player (pre 1.19)
 * senderName -- Name of the sender 
-* targetName -- Name of the target (for outgoing commands like /tell)
+* targetName -- Name of the target (for outgoing commands like /tell). Only in 1.19.2+
 * verified -- true if message is signed, false if not signed, undefined on versions prior to 1.19
 
 ### `systemChat` event

--- a/docs/API.md
+++ b/docs/API.md
@@ -271,6 +271,8 @@ Called when a chat message from another player arrives. The emitted object conta
 * type -- the message type - on 1.19, which format string to use to render message ; below, the place where the message is displayed (for example chat or action bar)
 * sender -- the UUID of the player sending the message
 * senderTeam -- scoreboard team of the player (pre 1.19)
+* senderName -- Name of the sender 
+* targetName -- Name of the target (for outgoing commands like /tell)
 * verified -- true if message is signed, false if not signed, undefined on versions prior to 1.19
 
 ### `systemChat` event

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -71,21 +71,10 @@ module.exports = function (client, options) {
             publicKey: crypto.createPublicKey({ key: player.crypto.publicKey, format: 'der', type: 'spki' }),
             publicKeyDER: player.crypto.publicKey,
             signature: player.crypto.signature,
-            displayName: player.displayName || player.name,
-            name: player.name
+            displayName: player.displayName || player.name
           }
           client._players[player.UUID].hasChainIntegrity = true
-        } else {
-          client._players[player.UUID] = {
-            displayName: player.displayName || player.name,
-            name: player.name
-          }
         }
-      }
-    } else if (packet.action === 3) {
-      for (const player of packet.data) {
-        if (!client._players[player.UUID]) continue
-        client._players[player.UUID].displayName = player.displayName || client._players[player.UUID].name
       }
     } else if (packet.action === 4) { // remove player
       for (const player of packet.data) {

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -143,8 +143,8 @@ module.exports = function (client, options) {
       formattedMessage: packet.formattedMessage,
       type: packet.type,
       sender: packet.senderUuid,
-      senderName: client._players[packet.senderUuid]?.displayName,
-      senderTeam: packet.senderTeam,
+      senderName: packet.networkName,
+      targetName: packet.networkTargetName,
       verified
     })
 


### PR DESCRIPTION
This adds senderName and targetName to playerChat event for version 1.19.2 so higher level libraries can properly render all chat types