### PR TITLE
Use consistent parameter naming for systemChat event

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -279,7 +279,7 @@ Called when a chat message from another player arrives. The emitted object conta
 
 Called when a system chat message arrives. A system chat message is any message not sent by a player. The emitted object contains:
 * formattedMessage -- the chat message preformatted
-* positionid -- the chat type of the message. 1 for system chat and 2 for actionbar
+* positionId -- the chat type of the message. 1 for system chat and 2 for actionbar
 
 See the [chat example](https://github.com/PrismarineJS/node-minecraft-protocol/blob/master/examples/client_chat/client_chat.js#L1) for usage.
 

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -158,7 +158,7 @@ module.exports = function (client, options) {
 
   client.on('system_chat', (packet) => {
     client.emit('systemChat', {
-      positionid: packet.isActionBar ? 2 : 1,
+      positionId: packet.isActionBar ? 2 : 1,
       formattedMessage: packet.content
     })
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,8 @@ declare module 'minecraft-protocol' {
 		on(event: 'connect', handler: () => PromiseLike): this
 		on(event: string, handler: (data: any, packetMeta: PacketMeta) => PromiseLike): this
 		on(event: `raw.${string}`, handler: (buffer: Buffer, packetMeta: PacketMeta) => PromiseLike): this
-		on(event: 'playerChat', handler: ({ formattedMessage: string, message: string, type: string, sender: string, senderName: string, senderTeam: string, verified?: boolean })): this
+		on(event: 'playerChat', handler: (data: { formattedMessage: string, message: string, type: string, sender: string, senderName: string, senderTeam: string, verified?: boolean }) => PromiseLike): this
+		on(event: 'systemChat', handler: (data: { positionId: number, formattedMessage: string }) => PromiseLike): this
 		once(event: 'error', listener: (error: Error) => PromiseLike): this
 		once(event: 'packet', handler: (data: any, packetMeta: PacketMeta, buffer: Buffer, fullBuffer: Buffer) => PromiseLike): this
 		once(event: 'raw', handler: (buffer: Buffer, packetMeta: PacketMeta) => PromiseLike): this


### PR DESCRIPTION
systemChat event currently uses lowercase naming for positionid in chat.js and camelCase in play.js