### PR TITLE
Fix client sending session packet when server is in offline mode

### DIFF
--- a/src/client/play.js
+++ b/src/client/play.js
@@ -19,7 +19,7 @@ module.exports = function (client, options) {
     client.uuid = packet.uuid
     client.username = packet.username
 
-    if (mcData.supportFeature('useChatSessions') && client.profileKeys) {
+    if (mcData.supportFeature('useChatSessions') && client.profileKeys && client._cipher) {
       client._session = {
         index: 0,
         uuid: uuid.v4fast()


### PR DESCRIPTION
Sending session packet on offline-mode servers would cause the client to be kicked for `multiplayer.disconnect.invalid_public_key_signature`. This will fix that by only sending session packet if server enables encryption (same check that the Vanilla client does)