### PR TITLE
Fix plugin channels support

### DIFF
--- a/examples/client_channel/client_channel.js
+++ b/examples/client_channel/client_channel.js
@@ -5,6 +5,14 @@ if (process.argv.length < 4 || process.argv.length > 6) {
   process.exit(1)
 }
 
+function getBrandChannelName () {
+  const mcData = require('minecraft-data')(client.version)
+  if (mcData.supportFeature('customChannelIdentifier')) {
+    return 'minecraft:brand' // 1.13+
+  }
+  return 'MC|Brand'
+}
+
 const client = mc.createClient({
   version: false,
   host: process.argv[2],
@@ -13,10 +21,11 @@ const client = mc.createClient({
   password: process.argv[5]
 })
 
-client.registerChannel('minecraft:brand', ['string', []])
-client.on('minecraft:brand', console.log)
+client.on('error', console.log)
 
 client.on('login', function () {
-  client.writeChannel('minecraft:brand', 'vanilla')
+  const brandChannel = getBrandChannelName()
+  client.registerChannel(brandChannel, ['string', []])
+  client.on(brandChannel, console.log)
+  client.writeChannel(brandChannel, 'vanilla')
 })
-client.on('error', console.log)

--- a/examples/client_channel/client_channel.js
+++ b/examples/client_channel/client_channel.js
@@ -13,10 +13,10 @@ const client = mc.createClient({
   password: process.argv[5]
 })
 
-client.registerChannel('MC|Brand', ['string', []])
-client.on('MC|Brand', console.log)
+client.registerChannel('minecraft:brand', ['string', []])
+client.on('minecraft:brand', console.log)
 
 client.on('login', function () {
-  client.writeChannel('MC|Brand', 'vanilla')
+  client.writeChannel('minecraft:brand', 'vanilla')
 })
 client.on('error', console.log)

--- a/examples/client_custom_channel/client_custom_channel.js
+++ b/examples/client_custom_channel/client_custom_channel.js
@@ -10,15 +10,15 @@ const client = mc.createClient({
   port: parseInt(process.argv[3]),
   username: process.argv[4] ? process.argv[4] : 'test',
   password: process.argv[5],
-  version: '1.10'
+  version: false
 })
 
 client.on('login', onlogin)
 client.on('error', console.log)
 
 function onlogin () {
-  client.registerChannel('CUSTOM|ChannelOne', ['i32', []], true)
-  client.registerChannel('CUSTOM|ChannelTwo', ['i32', []], true)
-  client.writeChannel('CUSTOM|ChannelOne', 4)
-  client.on('CUSTOM|ChannelTwo', console.log)
+  client.registerChannel('node-minecraft-protocol:custom_channel_one', ['string', []], true)
+  client.registerChannel('node-minecraft-protocol:custom_channel_two', ['string', []], true)
+  client.writeChannel('node-minecraft-protocol:custom_channel_one', 'hello from the client')
+  client.on('node-minecraft-protocol:custom_channel_two', console.log)
 }

--- a/examples/server_channel/server_channel.js
+++ b/examples/server_channel/server_channel.js
@@ -3,8 +3,6 @@ const mc = require('minecraft-protocol')
 const server = mc.createServer({
   'online-mode': false, // optional
   encryption: false, // optional
-  host: undefined, // optional
-  port: 25565, // optional
   version: '1.18.2'
 })
 const mcData = require('minecraft-data')(server.version)

--- a/examples/server_channel/server_channel.js
+++ b/examples/server_channel/server_channel.js
@@ -3,16 +3,16 @@ const mc = require('minecraft-protocol')
 const server = mc.createServer({
   'online-mode': false, // optional
   encryption: false, // optional
-  host: '0.0.0.0', // optional
+  host: undefined, // optional
   port: 25565, // optional
-  version: '1.16'
+  version: '1.18.2'
 })
 const mcData = require('minecraft-data')(server.version)
 const loginPacket = mcData.loginPacket
 
 server.on('login', function (client) {
-  client.registerChannel('MC|Brand', ['string', []])
-  client.on('MC|Brand', console.log)
+  client.registerChannel('minecraft:brand', ['string', []])
+  client.on('minecraft:brand', console.log)
 
   client.write('login', {
     entityId: client.id,
@@ -39,5 +39,5 @@ server.on('login', function (client) {
     pitch: 0,
     flags: 0x00
   })
-  client.writeChannel('MC|Brand', 'vanilla')
+  client.writeChannel('minecraft:brand', 'vanilla')
 })

--- a/examples/server_custom_channel/server_custom_channel.js
+++ b/examples/server_custom_channel/server_custom_channel.js
@@ -3,8 +3,6 @@ const mc = require('minecraft-protocol')
 const server = mc.createServer({
   'online-mode': false, // optional
   encryption: false, // optional
-  host: undefined, // optional
-  port: 25565, // optional
   version: '1.18.2'
 })
 const mcData = require('minecraft-data')(server.version)

--- a/examples/server_custom_channel/server_custom_channel.js
+++ b/examples/server_custom_channel/server_custom_channel.js
@@ -3,9 +3,9 @@ const mc = require('minecraft-protocol')
 const server = mc.createServer({
   'online-mode': false, // optional
   encryption: false, // optional
-  host: '0.0.0.0', // optional
+  host: undefined, // optional
   port: 25565, // optional
-  version: '1.16'
+  version: '1.18.2'
 })
 const mcData = require('minecraft-data')(server.version)
 const loginPacket = mcData.loginPacket
@@ -28,8 +28,8 @@ server.on('login', function (client) {
     isDebug: false,
     isFlat: false
   })
-  client.registerChannel('CUSTOM|ChannelOne', ['i32', []], true)
-  client.registerChannel('CUSTOM|ChannelTwo', ['i32', []], true)
+  client.registerChannel('node-minecraft-protocol:custom_channel_one', ['string', []], true)
+  client.registerChannel('node-minecraft-protocol:custom_channel_two', ['string', []], true)
   client.write('position', {
     x: 0,
     y: 1.62,
@@ -38,6 +38,6 @@ server.on('login', function (client) {
     pitch: 0,
     flags: 0x00
   })
-  client.writeChannel('CUSTOM|ChannelTwo', 10)
-  client.on('CUSTOM|ChannelOne', console.log)
+  client.writeChannel('node-minecraft-protocol:custom_channel_two', 'hello from the server')
+  client.on('node-minecraft-protocol:custom_channel_one', console.log)
 })

--- a/src/client/pluginChannels.js
+++ b/src/client/pluginChannels.js
@@ -14,14 +14,14 @@ module.exports = function (client, options) {
   client.unregisterChannel = unregisterChannel
   client.writeChannel = writeChannel
 
-  client.registerChannel('REGISTER', ['registerarr', []])
-  client.registerChannel('UNREGISTER', ['registerarr', []])
-
   const above385 = options.protocolVersion >= 385
   if (above385) { // 1.13-pre3 (385) added Added Login Plugin Message (https://wiki.vg/Protocol_History#1.13-pre3)
     client.on('login_plugin_request', onLoginPluginRequest)
   }
   const channelNames = above385 ? ['minecraft:register', 'minecraft:unregister'] : ['REGISTER', 'UNREGISTER']
+
+  client.registerChannel(channelNames[0], ['registerarr', []])
+  client.registerChannel(channelNames[1], ['registerarr', []])
 
   function registerChannel (name, parser, custom) {
     if (custom) {

--- a/src/client/pluginChannels.js
+++ b/src/client/pluginChannels.js
@@ -14,7 +14,7 @@ module.exports = function (client, options) {
   client.unregisterChannel = unregisterChannel
   client.writeChannel = writeChannel
 
-  const above385 = options.protocolVersion >= 385
+  const above385 = mcdata.version.version >= 385
   if (above385) { // 1.13-pre3 (385) added Added Login Plugin Message (https://wiki.vg/Protocol_History#1.13-pre3)
     client.on('login_plugin_request', onLoginPluginRequest)
   }


### PR DESCRIPTION
Fixes #1095

I believe this happens because the code wasn't updated in a while and it still expects the `REGISTER` channel to be in charge of channel registration:

https://github.com/PrismarineJS/node-minecraft-protocol/blob/70aee3d49432147c0814b6e94b16cc80a64959a8/src/client/pluginChannels.js#L17-L18

Bonus 😄: updated corresponding examples; they use stupidly long channel IDs now