### PR TITLE
Fix test for entityMetadata on 1.19.4

### DIFF
--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -243,6 +243,9 @@ for (const supportedVersion of mc.supportedVersions) {
   const mcData = require('minecraft-data')(supportedVersion)
   const version = mcData.version
   const packets = mcData.protocol
+  if (mcData.supportFeature('mcDataHasEntityMetadata')) {
+    values.entityMetadata[0].type = 'direction'
+  }
 
   describe('packets ' + version.minecraftVersion, function () {
     let client, server, serverClient

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -244,7 +244,9 @@ for (const supportedVersion of mc.supportedVersions) {
   const version = mcData.version
   const packets = mcData.protocol
   if (mcData.supportFeature('mcDataHasEntityMetadata')) {
-    values.entityMetadata[0].type = 'direction'
+    values.entityMetadata[0].type = 'byte'
+  } else {
+    values.entityMetadata[0].type = 0
   }
 
   describe('packets ' + version.minecraftVersion, function () {

--- a/test/packetTest.js
+++ b/test/packetTest.js
@@ -243,17 +243,17 @@ for (const supportedVersion of mc.supportedVersions) {
   const mcData = require('minecraft-data')(supportedVersion)
   const version = mcData.version
   const packets = mcData.protocol
-  if (mcData.supportFeature('mcDataHasEntityMetadata')) {
-    values.entityMetadata[0].type = 'byte'
-  } else {
-    values.entityMetadata[0].type = 0
-  }
 
   describe('packets ' + version.minecraftVersion, function () {
     let client, server, serverClient
     before(async function () {
       PORT = await getPort()
       server = new Server(version.minecraftVersion)
+      if (mcData.supportFeature('mcDataHasEntityMetadata')) {
+        values.entityMetadata[0].type = 'byte'
+      } else {
+        values.entityMetadata[0].type = 0
+      }
       return new Promise((resolve) => {
         console.log(`Using port for tests: ${PORT}`)
         server.once('listening', function () {


### PR DESCRIPTION
A field type was changed from int to a  named enum

match what was changed in mineflayer tests