### PR TITLE
Fix client sending chat_session_update when local UUID does not match UUID on server

### DIFF
--- a/src/client/play.js
+++ b/src/client/play.js
@@ -13,7 +13,7 @@ module.exports = function (client, options) {
 
   client.once('login', () => {
     const mcData = require('minecraft-data')(client.version)
-    if (mcData.supportFeature('useChatSessions') && client.profileKeys && client.cipher) {
+    if (mcData.supportFeature('useChatSessions') && client.profileKeys && client.cipher && client.session.selectedProfile.id === client.uuid.replace(/-/g, '')) {
       client._session = {
         index: 0,
         uuid: uuid.v4fast()


### PR DESCRIPTION
When connecting to an offline mode server behind an online mode proxy, the client will send a chat_session_update packet. On faulty (arguable) proxy implementations (e.g. Velocity), this packet will be forwarded to the backend server despite the backend being in offline mode. This will cause a signature mismatch on the server (because the offline mode UUID does not match the UUID we are signing with).

Possible fixes are:

1. Regenerate signature using the offline mode UUID
2. Don't send the chat_session_update packet

This PR implements fix 2, which mimics the behaviour of the Vanilla client.

Closes #1236 