### PR TITLE
Send chat commands as chat commands instead of chat messages for 1.19.3-1.20.1

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -388,7 +388,7 @@ module.exports = function (client, options) {
         timestamp: options.timestamp,
         salt: options.salt,
         argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
-        messageCount: client._lastSeenMessages.capacity,
+        messageCount: client._lastSeenMessages.pending,
         acknowledged
       })
       return

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -375,6 +375,7 @@ module.exports = function (client, options) {
           messageCount: client._lastSeenMessages.pending,
           acknowledged
         })
+        client._lastSeenMessages.pending = 0
       } else {
         client.write('chat_command', {
           command,

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -338,7 +338,7 @@ module.exports = function (client, options) {
     options.timestamp = options.timestamp || BigInt(Date.now())
     options.salt = options.salt || 1n
 
-    if (message.startsWith('/') && !mcData.supportFeature('useChatSessions')) {
+    if (message.startsWith('/')) {
       const command = message.slice(1)
       client.write('chat_command', {
         command,

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -346,6 +346,8 @@ module.exports = function (client, options) {
         salt: options.salt,
         argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
         signedPreview: options.didPreview,
+        messageCount: 0,
+        acknowledged: Buffer.alloc(3),
         previousMessages: client._lastSeenMessages.map((e) => ({
           messageSender: e.sender,
           messageSignature: e.signature

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -316,7 +316,7 @@ module.exports = function (client, options) {
     }
   })
 
-  function signaturesForCommand (string, ts, salt) {
+  function signaturesForCommand (string, ts, salt, preview, acknowledgements) {
     const signatures = []
     const slices = string.split(' ')
     if (sliceIndexForMessage[slices[0]]) {
@@ -324,7 +324,7 @@ module.exports = function (client, options) {
       const sliced = slices.slice(sliceIndex)
       if (sliced.length > 0) {
         const signable = sliced.join(' ')
-        signatures.push({ argumentName: fieldName, signature: client.signMessage(signable, ts, salt) })
+        signatures.push({ argumentName: fieldName, signature: client.signMessage(signable, ts, salt, preview, acknowledgements) })
       }
     }
     return signatures
@@ -366,12 +366,12 @@ module.exports = function (client, options) {
     if (message.startsWith('/')) {
       const command = message.slice(1)
       if (mcData.supportFeature('useChatSessions')) {
-        const { acknowledged } = getAcknowledgements()
+        const { acknowledged, acknowledgements } = getAcknowledgements()
         client.write('chat_command', {
           command,
           timestamp: options.timestamp,
           salt: options.salt,
-          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
+          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt, options.preview, acknowledgements),
           messageCount: client._lastSeenMessages.pending,
           acknowledged
         })

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -363,34 +363,33 @@ module.exports = function (client, options) {
     options.timestamp = options.timestamp || BigInt(Date.now())
     options.salt = options.salt || 1n
 
-    if (message.startsWith('/') && !mcData.supportFeature('useChatSessions')) {
+    if (message.startsWith('/')) {
       const command = message.slice(1)
-      client.write('chat_command', {
-        command,
-        timestamp: options.timestamp,
-        salt: options.salt,
-        argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
-        signedPreview: options.didPreview,
-        previousMessages: client._lastSeenMessages.map((e) => ({
-          messageSender: e.sender,
-          messageSignature: e.signature
-        })),
-        lastRejectedMessage: client._lastRejectedMessage
-      })
-      return
-    }
+      if (mcData.supportFeature('useChatSessions')) {
+        const { acknowledged } = getAcknowledgements()
+        client.write('chat_command', {
+          command,
+          timestamp: options.timestamp,
+          salt: options.salt,
+          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
+          messageCount: client._lastSeenMessages.pending,
+          acknowledged
+        })
+      } else {
+        client.write('chat_command', {
+          command,
+          timestamp: options.timestamp,
+          salt: options.salt,
+          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
+          signedPreview: options.didPreview,
+          previousMessages: client._lastSeenMessages.map((e) => ({
+            messageSender: e.sender,
+            messageSignature: e.signature
+          })),
+          lastRejectedMessage: client._lastRejectedMessage
+        })
+      }
 
-    if (message.startsWith('/') && mcData.supportFeature('useChatSessions')) {
-      const { acknowledged } = getAcknowledgements()
-      const command = message.slice(1)
-      client.write('chat_command', {
-        command,
-        timestamp: options.timestamp,
-        salt: options.salt,
-        argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
-        messageCount: client._lastSeenMessages.pending,
-        acknowledged
-      })
       return
     }
 


### PR DESCRIPTION
# motivation
Current behavior is that useChatSession capable protcols (1.19.3+) will send messages starting with '/' as a chat message (`client.write('chat_message', ...)`) instead of a chat command (`client.write('chat_command', ...)`) packet. This would cause chat commands to be sent as normal chat msgs and not be executed.
# change
This change makes it so that useChatSession protocols send chat commands as chat command packets.

~This change also prevents messages that have already been sent to the server from being sent again.~
# issues
~It fixes command messages for offline servers, but signing doesn't always seem to work for secure servers, so it continues to not work for those.~
