### PR TITLE
Fix end bundle bundle_delimiter packet not being emitted

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -94,8 +94,9 @@ class Client extends EventEmitter {
         debug(s && s.length > 10000 ? parsed.data : s)
       }
       if (parsed.metadata.name === 'bundle_delimiter') {
-        if (this._mcBundle.length) {
+        if (this._mcBundle.length) { // End bundle
           this._mcBundle.forEach(emitPacket)
+          emitPacket(parsed)
           this._mcBundle = []
         } else { // Start bundle
           this._mcBundle.push(parsed)


### PR DESCRIPTION
Currently NMP doesn't emit the `bundle_delimiter` packet if it is ending a bundle. 
Leading to issues like this for proxies: https://github.com/PrismarineJS/node-minecraft-protocol/issues/1242#issuecomment-1650606772
An easy way to recreate the issue is run the proxy example and mount a horse through the proxy, everything will freeze as it does not receive the closing `bundle_delimiter` packet so it doesn't process the bundle.

This fixes the issue by emitting the final `bundle_delimiter` packet. 