### PR TITLE
chat: Only sign command args when profile keys defined

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -371,7 +371,7 @@ module.exports = function (client, options) {
           command,
           timestamp: options.timestamp,
           salt: options.salt,
-          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt, options.preview, acknowledgements),
+          argumentSignatures: client.profileKeys ? signaturesForCommand(command, options.timestamp, options.salt, options.preview, acknowledgements) : [],
           messageCount: client._lastSeenMessages.pending,
           acknowledged
         })
@@ -381,7 +381,7 @@ module.exports = function (client, options) {
           command,
           timestamp: options.timestamp,
           salt: options.salt,
-          argumentSignatures: signaturesForCommand(command, options.timestamp, options.salt),
+          argumentSignatures: client.profileKeys ? signaturesForCommand(command, options.timestamp, options.salt) : [],
           signedPreview: options.didPreview,
           previousMessages: client._lastSeenMessages.map((e) => ({
             messageSender: e.sender,


### PR DESCRIPTION
I run a custom authentication server and I was getting the error:

```
Error: Can't sign message without profile keys, please set valid auth mode
```

when my bot issues the `/me` command. This patch changes the `argumentSignatures` field of the `chat_command` packet to only be calculated if `client.profileKeys` is valid, like the current behavior of the `chat_message` packet.