### PR TITLE
UnsignedContent correction for playerChat event.

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -198,7 +198,7 @@ module.exports = function (client, options) {
       if (verified) client._signatureCache.push(packet.signature)
       client.emit('playerChat', {
         plainMessage: packet.plainMessage,
-        unsignedContent: packet.unsignedContent,
+        unsignedContent: packet.unsignedChatContent,
         type: packet.type,
         sender: packet.senderUuid,
         senderName: packet.networkName,


### PR DESCRIPTION
When emitting one of `playerChat` events, there was used nonexisting `packet.unsignedContent`, to set `unsignedContent` field. So when using `playerChat` event, `unsignedContent` was `unknown`.