### PR TITLE
Acknowledge returning to configuration state if in play state.

### DIFF
--- a/src/client/play.js
+++ b/src/client/play.js
@@ -49,7 +49,7 @@ module.exports = function (client, options) {
       if (client.state === states.CONFIGURATION) return
       // If we are returning to the configuration state from the play state, we ahve to acknowledge it.
       if (client.state === states.PLAY) {
-        client.write('configuation_acknowledged', {})
+        client.write('configuration_acknowledged', {})
       }
       client.state = states.CONFIGURATION
       // Server should send finish_configuration on its own right after sending the client a dimension codec

--- a/src/client/play.js
+++ b/src/client/play.js
@@ -47,6 +47,10 @@ module.exports = function (client, options) {
 
     function enterConfigState () {
       if (client.state === states.CONFIGURATION) return
+      // If we are returning to the configuration state from the play state, we ahve to acknowledge it.
+      if (client.state === states.PLAY) {
+        client.write('configuation_acknowledged', {})
+      }
       client.state = states.CONFIGURATION
       // Server should send finish_configuration on its own right after sending the client a dimension codec
       // for login (that has data about world height, world gen, etc) after getting a login success from client


### PR DESCRIPTION
node-minecraft-protocol fix for part of https://github.com/PrismarineJS/mineflayer/issues/3292 

Seems we missed this detail of the configuration protocol since the server never normally transitions back into the config state. 