### PR TITLE
Fix handling of disconnect in versionChecking on 1.20.3+. 

### DIFF
--- a/src/client/versionChecking.js
+++ b/src/client/versionChecking.js
@@ -1,6 +1,9 @@
+const states = require('../states')
+
 module.exports = function (client, options) {
   client.on('disconnect', message => {
     if (!message.reason) { return }
+    if (client.state === states.PLAY | client.state === states.CONFIGURATION) { return }
     let parsed
     try {
       parsed = JSON.parse(message.reason)
@@ -11,7 +14,7 @@ module.exports = function (client, options) {
     let text = parsed.text ? parsed.text : parsed
     let versionRequired
 
-    if (text.translate && text.translate.startsWith('multiplayer.disconnect.outdated_')) { versionRequired = text.with[0] } else {
+    if (text.translate && (text.translate.startsWith('multiplayer.disconnect.outdated_') | text.translate.startsWith('multiplayer.disconnect.incompatible'))) { versionRequired = text.with[0] } else {
       if (text.extra) text = text.extra[0].text
       versionRequired = /(?:Outdated client! Please use|Outdated server! I'm still on) (.+)/.exec(text)
       versionRequired = versionRequired ? versionRequired[1] : null

--- a/src/client/versionChecking.js
+++ b/src/client/versionChecking.js
@@ -5,7 +5,7 @@ module.exports = function (client, options) {
     if (!message.reason) { return }
     // Prevent the disconnect packet handler in the versionChecking code from triggering on PLAY or CONFIGURATION state disconnects
     // Since version checking only happens during that HANDSHAKE / LOGIN state.
-    if (client.state === states.PLAY | client.state === states.CONFIGURATION) { return }
+    if (client.state === states.PLAY || client.state === states.CONFIGURATION) { return }
     let parsed
     try {
       parsed = JSON.parse(message.reason)
@@ -16,7 +16,7 @@ module.exports = function (client, options) {
     let text = parsed.text ? parsed.text : parsed
     let versionRequired
 
-    if (text.translate && (text.translate.startsWith('multiplayer.disconnect.outdated_') | text.translate.startsWith('multiplayer.disconnect.incompatible'))) {
+    if (text.translate && (text.translate.startsWith('multiplayer.disconnect.outdated_') || text.translate.startsWith('multiplayer.disconnect.incompatible'))) {
       versionRequired = text.with[0]
     } else {
       if (text.extra) text = text.extra[0].text

--- a/src/client/versionChecking.js
+++ b/src/client/versionChecking.js
@@ -3,6 +3,8 @@ const states = require('../states')
 module.exports = function (client, options) {
   client.on('disconnect', message => {
     if (!message.reason) { return }
+    // Prevent the disconnect packet handler in the versionChecking code from triggering on PLAY or CONFIGURATION state disconnects
+    // Making it so the handler only runs when a version related disconnect occurs.
     if (client.state === states.PLAY | client.state === states.CONFIGURATION) { return }
     let parsed
     try {
@@ -14,7 +16,9 @@ module.exports = function (client, options) {
     let text = parsed.text ? parsed.text : parsed
     let versionRequired
 
-    if (text.translate && (text.translate.startsWith('multiplayer.disconnect.outdated_') | text.translate.startsWith('multiplayer.disconnect.incompatible'))) { versionRequired = text.with[0] } else {
+    if (text.translate && (text.translate.startsWith('multiplayer.disconnect.outdated_') | text.translate.startsWith('multiplayer.disconnect.incompatible'))) {
+      versionRequired = text.with[0]
+    } else {
       if (text.extra) text = text.extra[0].text
       versionRequired = /(?:Outdated client! Please use|Outdated server! I'm still on) (.+)/.exec(text)
       versionRequired = versionRequired ? versionRequired[1] : null

--- a/src/client/versionChecking.js
+++ b/src/client/versionChecking.js
@@ -4,7 +4,7 @@ module.exports = function (client, options) {
   client.on('disconnect', message => {
     if (!message.reason) { return }
     // Prevent the disconnect packet handler in the versionChecking code from triggering on PLAY or CONFIGURATION state disconnects
-    // Making it so the handler only runs when a version related disconnect occurs.
+    // Since version checking only happens during that HANDSHAKE / LOGIN state.
     if (client.state === states.PLAY | client.state === states.CONFIGURATION) { return }
     let parsed
     try {


### PR DESCRIPTION
This fixes the versionChecking code catching disconnects from states other then Handshake and Login, which cause errors on 1.20.3+ where NBT chat is used for the Play and Configuration state.

Since version checking only occurs in Handshake / Login state its best not to do anything when those other states occur.

This also includes a fix for the translate string having changed for when you have a version miss match.