### PR TITLE
fix: wrap base64-encoded PEM with 64-char line boundary

### DIFF
--- a/src/client/encrypt.js
+++ b/src/client/encrypt.js
@@ -79,7 +79,7 @@ module.exports = function (client, options) {
 function mcPubKeyToPem (mcPubKeyBuffer) {
   let pem = '-----BEGIN PUBLIC KEY-----\n'
   let base64PubKey = mcPubKeyBuffer.toString('base64')
-  const maxLineLength = 65
+  const maxLineLength = 64
   while (base64PubKey.length > 0) {
     pem += base64PubKey.substring(0, maxLineLength) + '\n'
     base64PubKey = base64PubKey.substring(maxLineLength)


### PR DESCRIPTION
According to [RFC7468](https://datatracker.ietf.org/doc/html/rfc7468):

> Generators MUST wrap the base64-encoded lines so that each line
  consists of exactly 64 characters except for the final line, which
  will encode the remainder of the data (within the 64-character line
  boundary), and they MUST NOT emit extraneous whitespace.

Parsers can avoid branching and prevent timing sidechannel attacks. Ref https://arxiv.org/pdf/2108.04600.pdf

Fixes compatibility with Deno as it enforces stricter handling of PEM.