### PR TITLE
fix(server): fix for login_acknowledged on sync communication

### DIFF
--- a/src/server/login.js
+++ b/src/server/login.js
@@ -176,15 +176,17 @@ module.exports = function (client, server, options) {
       client.write('compress', { threshold: 256 }) // Default threshold is 256
       client.compressionThreshold = 256
     }
+    const isConfigStateSupported = client.supportFeature('hasConfigurationState');
+    if (isConfigStateSupported) {
+      client.once('login_acknowledged', onClientLoginAck)
+    }
     // TODO: find out what properties are on 'success' packet
     client.write('success', {
       uuid: client.uuid,
       username: client.username,
       properties: []
     })
-    if (client.supportFeature('hasConfigurationState')) {
-      client.once('login_acknowledged', onClientLoginAck)
-    } else {
+    if (!isConfigStateSupported) {
       client.state = states.PLAY
       server.emit('playerJoin', client)
     }


### PR DESCRIPTION
It works fine but it feels not correct. We could see it was breaking our testing setup along with the client part of minecraft-protocol, since we are using sync communication and the success packet emits `login_acknowledged` on the client side and that event is awaited only after the success event on the server side.
