### PR TITLE
Fix server-side `client.end()`

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -46,7 +46,6 @@ function createServer (options = {}) {
   server.onlineModeExceptions = Object.create(null)
   server.favicon = favicon
   server.options = options
-  server._supportFeature = mcData.supportFeature
   options.registryCodec = options.registryCodec || mcData.registryCodec || mcData.loginPacket?.dimensionCodec
 
   // The RSA keypair can take some time to generate

--- a/src/server.js
+++ b/src/server.js
@@ -29,7 +29,7 @@ class Server extends EventEmitter {
       client._end = client.end
       client.end = function end (endReason, fullReason) {
         if (client.state === states.PLAY) {
-          fullReason ||= this._supportFeature('chatPacketsUseNbtComponents')
+          fullReason ||= client._supportFeature('chatPacketsUseNbtComponents')
             ? nbt.comp({ text: nbt.string(endReason) })
             : JSON.stringify({ text: endReason })
           client.write('kick_disconnect', { reason: fullReason })

--- a/src/server/handshake.js
+++ b/src/server/handshake.js
@@ -9,8 +9,11 @@ module.exports = function (client, server, { version, fallbackVersion }) {
     client.protocolVersion = packet.protocolVersion
 
     if (version === false) {
-      if (require('minecraft-data')(client.protocolVersion)) {
+      const mcData = require('minecraft-data')(client.protocolVersion)
+      if (mcData) {
         client.version = client.protocolVersion
+        client._supportFeature = mcData.supportFeature
+        client._hasBundlePacket = mcData.supportFeature('hasBundlePacket')
       } else {
         let fallback
         if (fallbackVersion !== undefined) {
@@ -18,6 +21,8 @@ module.exports = function (client, server, { version, fallbackVersion }) {
         }
         if (fallback) {
           client.version = fallback.version.version
+          client._supportFeature = fallback.supportFeature
+          client._hasBundlePacket = fallback.supportFeature('hasBundlePacket')
         } else {
           client.end('Protocol version ' + client.protocolVersion + ' is not supported')
         }


### PR DESCRIPTION
To fix this error:
```bash
Disconnecting client because error TypeError [ERR_INVALID_ARG_TYPE]: SizeOf error for undefined : The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Object
    at Function.byteLength (node:buffer:766:11)
    at Object.string (eval at compile (~/test/node_modules/protodef/src/compiler.js:265:12), <anonymous>:78:25)
    at Object.packet_kick_disconnect (eval at compile (~/test/node_modules/protodef/src/compiler.js:265:12), <anonymous>:1110:27)
    at eval (eval at compile (~/test/node_modules/protodef/src/compiler.js:265:12), <anonymous>:2757:70)
    at packet (eval at compile (~/test/node_modules/protodef/src/compiler.js:265:12), <anonymous>:2842:9)
    at CompiledProtodef.sizeOf (~/test/node_modules/protodef/src/compiler.js:89:14)
    at e.message (~/test/node_modules/protodef/src/compiler.js:96:40)
    at tryCatch (~/test/node_modules/protodef/src/utils.js:50:16)
    at CompiledProtodef.createPacketBuffer (~/test/node_modules/protodef/src/compiler.js:96:20)
    at Serializer.createPacketBuffer (~/test/node_modules/protodef/src/serializer.js:12:23) {
  code: 'ERR_INVALID_ARG_TYPE',
  field: 'play.toClient'
}
```

Server code:
```js
const minecraftProtocol = require("minecraft-protocol");
let server = minecraftProtocol.createServer({
  "online-mode": true,
  encryption: true,
  host: "0.0.0.0",
  port: 25566,
  maxPlayers: 0,
  version: false,
  fallbackVersion: "1.19.2",
  motd: "Foobar"
});
server.on('login', function (client) {
  console.log("login")
  client.end(`text`);
});
```
Join a nmp server which support `chatPacketsUseNbtComponents` using Minecraft 1.19.2 