### PR TITLE
Chatjs: Spread into array

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -58,7 +58,7 @@ module.exports = function (client, options) {
 
       if (player.hasChainIntegrity) {
         const length = Buffer.byteLength(message, 'utf8')
-        const acknowledgements = previousMessages.length > 0 ? ['i32', previousMessages.length, 'buffer', Buffer.concat(...previousMessages.map(msg => msg.signature || client._signatureCache[msg.id]))] : ['i32', 0]
+        const acknowledgements = previousMessages.length > 0 ? ['i32', previousMessages.length, 'buffer', Buffer.concat([...previousMessages.map(msg => msg.signature || client._signatureCache[msg.id])])] : ['i32', 0]
 
         const signable = concat('i32', 1, 'UUID', uuid, 'UUID', player.sessionUuid, 'i32', index, 'i64', salt, 'i64', timestamp / 1000n, 'i32', length, 'pstring', message, ...acknowledgements)
 


### PR DESCRIPTION
I was using Mineflayer and got the error when using a chat event:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "list" argument must be an instance of Array. Received an instance of Buffer
    at Buffer.concat (node:buffer:580:3)
    at updateAndValidateSession (./node_modules/minecraft-protocol/src/client/chat.js:61:36)
```

this fixed my issue on MC 1.21.4 
Was using latest mineflayer on node 24.4.0

Not too familiar with js/node environment, but hope this (very small) PR helps!