### PR TITLE
Fix undefined chat message signatures causing crash

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -58,7 +58,7 @@ module.exports = function (client, options) {
 
       if (player.hasChainIntegrity) {
         const length = Buffer.byteLength(message, 'utf8')
-        const acknowledgements = previousMessages.length > 0 ? ['i32', previousMessages.length, 'buffer', Buffer.concat(...previousMessages.map(msg => msg.signature || client._signatureCache[msg.id]))] : ['i32', 0]
+        const acknowledgements = previousMessages.length > 0 ? ['i32', previousMessages.length, 'buffer', Buffer.concat(previousMessages.map(msg => msg.signature || client._signatureCache[msg.id]).filter(buf => Buffer.isBuffer(buf)))] : ['i32', 0]
 
         const signable = concat('i32', 1, 'UUID', uuid, 'UUID', player.sessionUuid, 'i32', index, 'i64', salt, 'i64', timestamp / 1000n, 'i32', length, 'pstring', message, ...acknowledgements)
 

--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -60,12 +60,12 @@ module.exports = function (client, options) {
         const length = Buffer.byteLength(message, 'utf8')
         const validBuffers = previousMessages
           .filter(msg => msg.signature || client._signatureCache[msg.id]) // Filter out invalid messages
-          .map(msg => msg.signature || client._signatureCache[msg.id])   // Map to signatures
-          .filter(buf => Buffer.isBuffer(buf));                          // Ensure only Buffers are included
+          .map(msg => msg.signature || client._signatureCache[msg.id])
+          .filter(buf => Buffer.isBuffer(buf))
 
         const acknowledgements = validBuffers.length > 0
           ? ['i32', validBuffers.length, 'buffer', Buffer.concat(validBuffers)]
-          : ['i32', 0]; // Handle empty array case
+          : ['i32', 0]
         const signable = concat('i32', 1, 'UUID', uuid, 'UUID', player.sessionUuid, 'i32', index, 'i64', salt, 'i64', timestamp / 1000n, 'i32', length, 'pstring', message, ...acknowledgements)
 
         player.hasChainIntegrity = crypto.verify('RSA-SHA256', signable, player.publicKey, currentSignature)


### PR DESCRIPTION
Trying to listen for chat messages while server is on localhost makes the bot crash because of undefined buffers. This change in code filters them out.