### PR TITLE
fix: emitting playerJoin too early

### DIFF
--- a/src/server/login.js
+++ b/src/server/login.js
@@ -190,7 +190,6 @@ module.exports = function (client, server, options) {
       client.once('login_acknowledged', onClientLoginAck)
     } else {
       client.state = states.PLAY
-      server.emit('playerJoin', client)
     }
     client.settings = {}
 
@@ -217,6 +216,9 @@ module.exports = function (client, server, options) {
     pluginChannels(client, options)
     if (client.supportFeature('signedChat')) chatPlugin(client, server, options)
     server.emit('login', client)
+    if (!client.supportFeature('hasConfigurationState')) {
+      server.emit('playerJoin', client)
+    }
   }
 
   function onClientLoginAck () {


### PR DESCRIPTION
As doc suggests:
Emitted after the player enters the PLAY state and **can send and recieve game packets**

Howerver in old implementation for old versions (before 1.20) pluginChannels is not registered yet, let's register it first to avoid crashes and align the behavior between post and pre 1.20.