### PR TITLE
Backport velocity field changes from 1.21.9+ to older versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,5 @@ jobs:
         distribution: 'adopt'
     - name: Install dependencies
       run: npm install
-    - run: cd node_modules && cd minecraft-data && mv minecraft-data minecraft-data-old && git clone -b consistent-velocity https://github.com/SuperGamerTron/minecraft-data --depth 1 && node bin/generate_data.js  
     - name: Run tests
       run: npm run mochaTest -- -g ${{ matrix.mcVersion }}v


### PR DESCRIPTION
After https://github.com/PrismarineJS/minecraft-data/pull/1153