### PR TITLE
fix aresrpg repo link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ node-minecraft-protocol is pluggable.
    servers with a high level API, also a minecraft server by itself.
  * [pakkit](https://github.com/Heath123/pakkit) - A GUI tool to monitor Minecraft packets in real time, allowing you to view their data and interactively edit and resend them.
  * [minecraft-packet-debugger](https://github.com/wvffle/minecraft-packet-debugger) - A tool to capture Minecraft packets in a buffer then view them in a browser.
- * [aresrpg](https://github.com/aresrpg/aresrpg) - An open-source mmorpg minecraft server.
+ * [aresrpg](https://github.com/aresrpg/aresrpg-mc) - An open-source mmorpg minecraft server.
  * [SteveProxy](https://github.com/SteveProxy/proxy) - Proxy for Minecraft with the ability to change the gameplay using plugins.
  * and [several thousands others](https://github.com/PrismarineJS/node-minecraft-protocol/network/dependents?package_id=UGFja2FnZS0xODEzMDk0OQ%3D%3D)
 


### PR DESCRIPTION
was going to set up a project and noticed the link for the aresrpg project was broken. They created a hytale project, so the original repository for minecraft got renamed to `aresrpg-mc` , so this PR just fixes the link to it in the README.