### PR TITLE
Fix computeChatChecksum returning unsigned byte for i8 schema (closes #1482)

### DIFF
--- a/src/datatypes/checksums.js
+++ b/src/datatypes/checksums.js
@@ -12,9 +12,11 @@ function computeChatChecksum (lastSeenMessages) {
       checksum = (31 * checksum + sigHash) & 0xffffffff
     }
   }
-  // Convert to byte
-  const result = checksum & 0xff
-  return result === 0 ? 1 : result
+  // Convert to signed byte (i8: -128..127) to match the chat_command_signed packet schema.
+  // The previous `& 0xff` produced 0..255 which causes RangeError when value > 127.
+  const unsigned = checksum & 0xff
+  const signed = unsigned > 127 ? unsigned - 256 : unsigned
+  return signed === 0 ? 1 : signed
 }
 
 module.exports = { computeChatChecksum }


### PR DESCRIPTION
## Summary

The `chat_command_signed` packet schema defines the checksum as `i8` (-128..127), but `computeChatChecksum` was returning the result of `& 0xff` (0..255). When the masked checksum exceeded 127, the protocol writer rejected it with `RangeError: The value of \"value\" is out of range. It must be >= -128 and <= 127. Received N`, breaking any signed slash command on MC 1.21.11.

Closes #1482.

## Fix

Convert the unsigned byte to signed range before returning:

```js
const unsigned = checksum & 0xff
const signed = unsigned > 127 ? unsigned - 256 : unsigned
return signed === 0 ? 1 : signed
```

## Test plan

- [x] Locally patched `node_modules/minecraft-protocol/src/datatypes/checksums.js` with the same conversion against MC 1.21.11 vanilla server (LAN), bot has been sending `/say` / `/tell` for ~14 days without RangeError.
- [ ] Adding a unit test to the repo would be nice — happy to follow up if reviewers want one in this PR.

## Notes

Issue #1482 has the full repro steps (versions, error, root cause). This PR is the minimal fix; the value-zero guard (`return 1`) is preserved.