### PR TITLE
Revert "Fix computeChatChecksum returning unsigned byte for i8 schema (closes #1482)"

### DIFF
--- a/src/datatypes/checksums.js
+++ b/src/datatypes/checksums.js
@@ -12,11 +12,9 @@ function computeChatChecksum (lastSeenMessages) {
       checksum = (31 * checksum + sigHash) & 0xffffffff
     }
   }
-  // Convert to signed byte (i8: -128..127) to match the chat_command_signed packet schema.
-  // The previous `& 0xff` produced 0..255 which causes RangeError when value > 127.
-  const unsigned = checksum & 0xff
-  const signed = unsigned > 127 ? unsigned - 256 : unsigned
-  return signed === 0 ? 1 : signed
+  // Convert to byte
+  const result = checksum & 0xff
+  return result === 0 ? 1 : result
 }
 
 module.exports = { computeChatChecksum }


### PR DESCRIPTION
Reverts PrismarineJS/node-minecraft-protocol#1485 as issue has been fixed in data in PrismarineJS/minecraft-data#1188