### PR TITLE
Fix missing variable in client_auto.js: replace undeclared 'packet'

### DIFF
--- a/examples/client_auto/client_auto.js
+++ b/examples/client_auto/client_auto.js
@@ -29,4 +29,10 @@ client.on('chat', function (packet) {
     if (username === client.username) return
     client.write('chat', { message: msg })
   }
+  if (jsonMsg.translate === 'chat.type.announcement' || jsonMsg.translate === 'chat.type.text') {
+    const username = jsonMsg.with[0].text
+    const msg = jsonMsg.with[1]
+    if (username === client.username) return
+    client.write('chat', { message: msg })
+  }
 })


### PR DESCRIPTION
In client_auto.js, line attempting to parse `packet.message` references an undeclared variable `packet` (should be `jsonMsg`). This causes a crash when a chat event is received. Fixed by replacing `packet` with the correct variable.