### PR TITLE
compression: enforce maximum uncompressed packet size

### DIFF
--- a/src/transforms/compression.js
+++ b/src/transforms/compression.js
@@ -4,6 +4,11 @@ const [readVarInt, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
 const zlib = require('zlib')
 const Transform = require('readable-stream').Transform
 
+// The protocol caps the uncompressed size of a packet at 2^23 bytes (8 MiB). A compressed
+// packet that declares — or inflates to — more than this is rejected, so a malicious peer
+// cannot force an unbounded synchronous allocation (a "decompression bomb"). See #664.
+const MAX_UNCOMPRESSED_LENGTH = 8388608 // 2 ** 23
+
 module.exports.createCompressor = function (threshold) {
   return new Compressor(threshold)
 }
@@ -53,9 +58,15 @@ class Decompressor extends Transform {
     if (value === 0) {
       this.push(chunk.slice(size))
       return cb()
+    } else if (value > MAX_UNCOMPRESSED_LENGTH) {
+      // Declared uncompressed length exceeds the protocol maximum; refuse to inflate.
+      if (!this.hideErrors) {
+        console.error('uncompressed length ' + value + ' exceeds maximum of ' + MAX_UNCOMPRESSED_LENGTH)
+      }
+      return cb()
     } else {
       try {
-        const newBuf = zlib.unzipSync(chunk.slice(size), { finishFlush: 2 })
+        const newBuf = zlib.unzipSync(chunk.slice(size), { maxOutputLength: MAX_UNCOMPRESSED_LENGTH, finishFlush: 2 })
         if (newBuf.length !== value && !this.hideErrors) {
           console.error('uncompressed length should be ' + value + ' but is ' + newBuf.length)
         }

--- a/test/compressionTest.js
+++ b/test/compressionTest.js
@@ -1,0 +1,66 @@
+/* eslint-env mocha */
+// Tests the compression transforms, in particular that the decompressor enforces the
+// protocol's maximum uncompressed packet size so a malicious peer cannot send a
+// "decompression bomb" that inflates to an unbounded synchronous allocation. See #664.
+const assert = require('assert')
+const zlib = require('zlib')
+const [, writeVarInt, sizeOfVarInt] = require('protodef').types.varint
+const { supportedVersions } = require('../src/version')
+const { createCompressor, createDecompressor } = require('../src/transforms/compression')
+
+const MAX_UNCOMPRESSED_LENGTH = 8388608 // 2 ** 23
+
+// Push a single chunk through a transform and resolve with the array of emitted chunks.
+function pump (transform, chunk) {
+  return new Promise((resolve, reject) => {
+    const out = []
+    transform.on('data', (d) => out.push(d))
+    transform.on('error', reject)
+    transform.write(chunk, (err) => {
+      if (err) return reject(err)
+      setImmediate(() => resolve(out))
+    })
+  })
+}
+
+// Build a compressed-packet frame: a VarInt declared uncompressed length followed by `payload`.
+function framePacket (declaredLength, payload) {
+  const header = Buffer.alloc(sizeOfVarInt(declaredLength))
+  writeVarInt(declaredLength, header, 0)
+  return Buffer.concat([header, payload])
+}
+
+// The transforms are version-independent, but the test job filters by `-g <version>v`,
+// so the suite is registered per supported version to run under CI.
+for (const supportedVersion of supportedVersions) {
+  describe('compression ' + supportedVersion + 'v', () => {
+    it('round-trips a compressed packet', async () => {
+      const original = Buffer.from('a payload long enough to be worth compressing'.repeat(8))
+      const [compressed] = await pump(createCompressor(0), original)
+      const [restored] = await pump(createDecompressor(0), compressed)
+      assert.ok(restored.equals(original), 'decompressed output should equal the original')
+    })
+
+    it('passes through an uncompressed packet (declared length 0)', async () => {
+      const original = Buffer.from('small')
+      // threshold above the payload size -> compressor emits it uncompressed (VarInt 0 prefix)
+      const [framed] = await pump(createCompressor(256), original)
+      const [restored] = await pump(createDecompressor(256), framed)
+      assert.ok(restored.equals(original))
+    })
+
+    it('drops a decompression bomb instead of allocating past the maximum', async () => {
+      // Payload inflates to more than the protocol maximum, but declares a small length.
+      const bomb = zlib.deflateSync(Buffer.alloc(MAX_UNCOMPRESSED_LENGTH + 1024))
+      const packet = framePacket(100, bomb)
+      const out = await pump(createDecompressor(0, true), packet)
+      assert.strictEqual(out.length, 0, 'oversized inflate should be dropped, not emitted')
+    })
+
+    it('rejects a packet whose declared uncompressed length exceeds the maximum', async () => {
+      const packet = framePacket(MAX_UNCOMPRESSED_LENGTH + 1, zlib.deflateSync(Buffer.from('x')))
+      const out = await pump(createDecompressor(0, true), packet)
+      assert.strictEqual(out.length, 0, 'over-cap declared length should be dropped before inflating')
+    })
+  })
+}

--- a/test/compressionTest.js
+++ b/test/compressionTest.js
@@ -62,5 +62,12 @@ for (const supportedVersion of supportedVersions) {
       const out = await pump(createDecompressor(0, true), packet)
       assert.strictEqual(out.length, 0, 'over-cap declared length should be dropped before inflating')
     })
+
+    it('round-trips a packet at the maximum uncompressed length', async () => {
+      const original = Buffer.alloc(MAX_UNCOMPRESSED_LENGTH, 0)
+      const [compressed] = await pump(createCompressor(0), original)
+      const [restored] = await pump(createDecompressor(0), compressed)
+      assert.ok(restored.equals(original))
+    })
   })
 }


### PR DESCRIPTION
## Problem

`Decompressor` in `src/transforms/compression.js` inflates compressed packets with
`zlib.unzipSync(..., { finishFlush: 2 })` and no bound on the output size. The declared
uncompressed length is read but only used for a `console.error`, never enforced, so a peer can
send a small, highly compressible packet that inflates to an arbitrarily large synchronous
allocation and OOMs the process. This is the behavior reported in #664 (*"Players know about
this bug, and are actively exploiting it to ... effectively 'ban' them"*); the earlier #729
capped only the outbound `Compressor` and was closed, so the inbound path is still unbounded.
Resolves #664.

The transform is shared by both pipelines, so this affects clients/bots (malicious server) and
any `node-minecraft-protocol` server (malicious client) symmetrically.

## Fix

Enforce the protocol's maximum uncompressed packet size of `2 ** 23` (8388608) bytes — the value
vanilla applies in `NettyCompressionDecoder`:

- pass `maxOutputLength` to `zlib.unzipSync`, so a packet that inflates past the cap throws
  `ERR_BUFFER_TOO_LARGE` and is dropped by the existing error handler instead of allocating
  without bound; and
- reject up front any packet whose declared uncompressed length already exceeds the cap.

No behavior change for spec-compliant traffic — every legitimate packet is ≤ 8 MiB uncompressed,
and anything larger is already rejected by a vanilla client.

## Test

New `test/compressionTest.js`, exercising the transforms directly (no server jar):

- compressed round-trip and uncompressed (`value === 0`) passthrough — the no-regression cases;
- a decompression bomb (declares a small length, inflates past the cap) is dropped instead of
  emitted — the assertion fails on `master`, which inflates and forwards it;
- a packet whose declared length already exceeds the cap is rejected before inflating;
- boundary: an exactly-`2 ** 23`-byte packet still round-trips, since the cap rejects only output
  *past* the maximum — legitimate max-size packets are unaffected.

`npm test` green locally (`standard` plus mocha).

## Scope

Intentionally narrow. The `Splitter` in `framing.js` also buffers an attacker-declared frame
length with no maximum — the same class of issue, but a separate change; I'll propose a
max-frame-size cap in a follow-up PR rather than widen this one.