### PR TITLE
Send Client Information (settings) packet during configuration phase

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -147,6 +147,15 @@ Returns a `Client` instance and perform login.
  * id : a numeric client id used for referring to multiple clients in a server
  * validateChannelProtocol (optional) : whether or not to enable protocol validation for custom protocols using plugin channels. Defaults to true
  * disableChatSigning (optional) : Don't try obtaining chat signing keys from Mojang (1.19+)
+ * clientSettings (optional) : Client Information (settings) sent to the server during the configuration phase (1.20.2+). All fields are optional and default to vanilla-safe values:
+   * locale : language/locale string, default `'en_us'`
+   * viewDistance : view distance in chunks, default `10`
+   * chatFlags : chat mode, `0` = enabled, `1` = commands only, `2` = hidden, default `0`
+   * chatColors : whether chat colors are enabled, default `true`
+   * skinParts : displayed skin parts bitmask, default `127`
+   * mainHand : `0` = left, `1` = right, default `1`
+   * enableTextFiltering : default `false`
+   * enableServerListing : whether the player appears in server status player samples, default `true`
  * realms : An object which should contain one of the following properties: `realmId` or `pickRealm`. When defined will attempt to join a Realm without needing to specify host/port. **The authenticated account must either own the Realm or have been invited to it**
    * realmId : The id of the Realm to join.
    * pickRealm(realms) : A function which will have an array of the user Realms (joined/owned) passed to it. The function should return a Realm.

--- a/src/client/play.js
+++ b/src/client/play.js
@@ -55,17 +55,21 @@ module.exports = function (client, options) {
       client.state = states.CONFIGURATION
       // Mirror the vanilla client, which sends Client Information during the
       // configuration phase. Some servers (e.g. Hypixel) wait for it before
-      // sending finish_configuration and close the socket otherwise. Must be
-      // after the CONFIGURATION state flip so it serializes correctly. (#3623)
+      // sending finish_configuration and will close the socket otherwise.
+      // Defaults are vanilla-safe and can be overridden per-field via the
+      // `clientSettings` option. A client that also sends Client Information in
+      // the play state (e.g. mineflayer on its 'login' event) still takes
+      // precedence there, exactly as the vanilla client re-sends settings. (#3623)
+      const clientSettings = options.clientSettings || {}
       client.write('settings', {
-        locale: 'en_us',
-        viewDistance: 10,
-        chatFlags: 0,
-        chatColors: true,
-        skinParts: 127,
-        mainHand: 1,
-        enableTextFiltering: false,
-        enableServerListing: true
+        locale: clientSettings.locale ?? 'en_us',
+        viewDistance: clientSettings.viewDistance ?? 10,
+        chatFlags: clientSettings.chatFlags ?? 0,
+        chatColors: clientSettings.chatColors ?? true,
+        skinParts: clientSettings.skinParts ?? 127,
+        mainHand: clientSettings.mainHand ?? 1,
+        enableTextFiltering: clientSettings.enableTextFiltering ?? false,
+        enableServerListing: clientSettings.enableServerListing ?? true
       })
       client.once('select_known_packs', () => {
         client.write('select_known_packs', { packs: [] })

--- a/src/client/play.js
+++ b/src/client/play.js
@@ -53,6 +53,20 @@ module.exports = function (client, options) {
         client.write('configuration_acknowledged', {})
       }
       client.state = states.CONFIGURATION
+      // Mirror the vanilla client, which sends Client Information during the
+      // configuration phase. Some servers (e.g. Hypixel) wait for it before
+      // sending finish_configuration and close the socket otherwise. Must be
+      // after the CONFIGURATION state flip so it serializes correctly. (#3623)
+      client.write('settings', {
+        locale: 'en_us',
+        viewDistance: 10,
+        chatFlags: 0,
+        chatColors: true,
+        skinParts: 127,
+        mainHand: 1,
+        enableTextFiltering: false,
+        enableServerListing: true
+      })
       client.once('select_known_packs', () => {
         client.write('select_known_packs', { packs: [] })
       })


### PR DESCRIPTION
On 1.20.2+ the vanilla client sends Client Information (`settings`) during the
configuration phase; node-minecraft-protocol never does. Servers that gate
`finish_configuration` on it (e.g. Hypixel) never advance and drop the client
with `socketClosed` right after `login_acknowledged` — so bots can't join on
1.20.2–1.21.x.

Fix: write `settings` immediately after the `CONFIGURATION` state flip in
`enterConfigState` (inside the existing `hasConfigurationState` branch, so 1.20.2+
only). `particleStatus` (1.21.2+) is omitted so one payload serializes on every
config-phase version.

Supersedes #1402, which wrote the packet before the state flip (still `login`
state → serialization error → CI failed on exactly 1.20.2–1.21.4).

Tested: lint, serverTest (319), packet/cyclePacket (5983), and real-server
clientTest on 1.21.4 + 1.21.9 all pass. mineflayer joins Hypixel 1.21.9 with this
change; `socketClosed` without.

Fixes PrismarineJS/mineflayer#3623