### PR TITLE
Add client_transfer example

### DIFF
--- a/examples/client_transfer/client_transfer.js
+++ b/examples/client_transfer/client_transfer.js
@@ -1,0 +1,44 @@
+// Demonstrates following a server-initiated Transfer packet (added in 1.20.5, used by
+// the vanilla /transfer command and by proxies/plugins that hand a player off to a
+// different server, e.g. for load balancing or a low-latency regional server).
+//
+// The important part is the reconnect: end() the current connection and wait for it to
+// fully close, then wait a short beat, before connecting to the new host:port with the
+// same username. Reconnecting immediately can race the server's own cleanup of the old
+// session and get rejected with "already playing on the server" (Bukkit/Paper's
+// duplicate-login check), since the server hasn't necessarily finished processing the
+// old connection's teardown yet.
+const mc = require('minecraft-protocol')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node client_transfer.js <host> <port> [<name>]')
+  process.exit(1)
+}
+
+const host = process.argv[2]
+const port = parseInt(process.argv[3])
+const username = process.argv[4] || 'transfer_bot'
+
+function connect (host, port) {
+  const client = mc.createClient({ host, port, username })
+
+  client.on('connect', () => console.log(`connecting to ${host}:${port}`))
+  client.on('login', () => console.log(`logged in to ${host}:${port}`))
+  client.on('error', (err) => console.error('error:', err))
+  client.on('disconnect', (packet) => console.log('disconnected:', packet.reason))
+  client.on('kick_disconnect', (packet) => console.log('kicked:', packet.reason))
+
+  client.on('transfer', async (packet) => {
+    console.log(`received transfer packet -> ${packet.host}:${packet.port}, reconnecting`)
+    await new Promise((resolve) => {
+      client.once('end', resolve)
+      client.end()
+    })
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    connect(packet.host, packet.port)
+  })
+
+  return client
+}
+
+connect(host, port)

--- a/examples/client_transfer/package.json
+++ b/examples/client_transfer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "node-minecraft-protocol-example",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+  },
+  "description": "A node-minecraft-protocol example"
+}


### PR DESCRIPTION
## Summary
- No example or doc mention of the Transfer packet (added in 1.20.5) existed anywhere in this repo, despite the protocol data already fully supporting it.
- Adds `examples/client_transfer`, showing the correct way to follow a server-initiated transfer: end the current connection, wait for it to actually close, add a short grace period, then reconnect to the new host:port with the same username.
- That reconnect timing matters: an immediate reconnect can race the server's own cleanup of the old session and get rejected with "already playing on the server" (Bukkit/Paper's duplicate-login check). Hit this myself while building the example and fixed it with the wait-for-`end` + delay shown here.
- mineflayer has an open bug in the same area (PrismarineJS/mineflayer#3776: sends physics packets during the configuration phase a transfer triggers, which 1.21+ servers reject), so this seemed worth documenting at the protocol level directly.

## Test plan
- [x] `npx standard examples/client_transfer/client_transfer.js` passes with no changes needed
- [x] Ran the example (using this repo's own `src`, not a published version) against a real Paper/Purpur 1.21.10 server performing a real transfer handoff between two hosts, confirmed both the initial login and the post-transfer login succeed:
  ```
  connecting to <host1>:25565
  logged in to <host1>:25565
  received transfer packet -> <host2>:25565, reconnecting
  connecting to <host2>:25565
  logged in to <host2>:25565
  ```