### PR TITLE
Fix errors caused by missing `signature` in packet `player_chat`

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -196,7 +196,7 @@ module.exports = function (client, options) {
     if (mcData.supportFeature('useChatSessions')) {
       const tsDelta = BigInt(Date.now()) - packet.timestamp
       const expired = !packet.timestamp || tsDelta > messageExpireTime || tsDelta < 0
-      const verified = !packet.unsignedChatContent && updateAndValidateSession(packet.senderUuid, packet.plainMessage, packet.signature, packet.index, packet.previousMessages, packet.salt, packet.timestamp) && !expired
+      const verified = packet.signature && !packet.unsignedChatContent && updateAndValidateSession(packet.senderUuid, packet.plainMessage, packet.signature, packet.index, packet.previousMessages, packet.salt, packet.timestamp) && !expired
       if (verified) client._signatureCache.push(packet.signature)
       client.emit('playerChat', {
         globalIndex: packet.globalIndex,


### PR DESCRIPTION
Replaces #1509 (original by @TAOtxi, branch became unpushable after maintainer edits were disabled).

## Problem

On offline servers (tested on 1.21.11), running `bot.chat('/w xx something')` causes the bot to receive a `player_chat` packet without a `signature` attribute, which raises an error at `src/client/chat.js:199`:

```
const verified = !packet.unsignedChatContent && updateAndValidateSession(packet.senderUuid, packet.plainMessage, packet.signature, packet.index, packet.previousMessages, packet.salt, packet.timestamp) && !expired
```

`packet.signature` is declared as `option` in the protocol data, so it is `undefined` when the server does not sign the message. `updateAndValidateSession` then passes it to `crypto.verify('RSA-SHA256', ...)`, which throws a `TypeError` and kills the packet handler before `playerChat` is emitted.

## Fix

Short-circuit on a missing signature before attempting validation, matching vanilla behavior:

- `PlayerChatMessage#verify` null-checks the signature before verifying (`this.signature != null && ...`)
- `ChatTrustLevel#evaluate` treats a missing signature as `NOT_SECURE` — the message is still displayed, just flagged; it is never an error condition

With this change, `verified` is `false` for unsigned messages and the `playerChat` event still fires.

The same guard is not needed in the 1.19.1 `chainedChatWithHashing` branch, where `signature` is declared as a required buffer in the protocol data.