### PR TITLE
types: add missing encryption option to ServerOptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -195,6 +195,8 @@ declare module 'minecraft-protocol' {
 		kickTimeout?: number
 		checkTimeoutInterval?: number
 		'online-mode'?: boolean
+		/** Whether to enable encryption (handshake + encrypted transport). Used together with online-mode. */
+		encryption?: boolean
 		beforePing?: (response: any, client: Client, callback?: (error: any, result: any) => any) => any
 		beforeLogin?: (client: Client) => void
 		motd?: string


### PR DESCRIPTION
Fixes #1503

## Problem
The README's "Hello World server example" passes `encryption: true` to `mc.createServer(...)`, and the option is used in several examples (`examples/server_world`, `examples/server_channel`, `examples/server_custom_channel`) and documented in HISTORY.md (renamed from `encryption-enabled` to `encryption`). However, `encryption` was missing from the `ServerOptions` interface in `src/index.d.ts`, so TypeScript users got an "Object literal may only specify known properties" error when following the documented example.

## Fix
Added the missing optional `encryption?: boolean` property to `ServerOptions`:

```ts
export interface ServerOptions {
    ...
    'online-mode'?: boolean
    /** Whether to enable encryption (handshake + encrypted transport). Used together with online-mode. */
    encryption?: boolean
    ...
}
```

## Verified
- `tsc --noEmit --skipLibCheck src/index.d.ts` passes with the change.
- The property matches the documented README example and the existing examples that pass `encryption` to `createServer`.