### PR TITLE
test: retry the vanilla ping while the server has no status yet

### DIFF
--- a/test/clientTest.js
+++ b/test/clientTest.js
@@ -13,6 +13,19 @@ const { getPort } = require('./common/util')
 const SURVIVE_TIME = 10000
 const MC_SERVER_PATH = path.join(__dirname, 'server')
 
+// Vanilla logs the "Done" line startServer waits on before it builds its status object,
+// and closes any status request that arrives in between without a reply (1.19.4+).
+async function pingWhenReady (options, attempts = 20) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await mc.ping(options)
+    } catch (err) {
+      if (attempt === attempts || !/closed before the server sent a status response/.test(err.message)) throw err
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+  }
+}
+
 const Wrap = require('minecraft-wrap').Wrap
 
 for (const supportedVersion of mc.supportedVersions) {
@@ -79,25 +92,22 @@ for (const supportedVersion of mc.supportedVersions) {
         })
       })
 
-      it('pings the server', function (done) {
-        mc.ping({
+      it('pings the server', async function () {
+        const results = await pingWhenReady({
           version: version.minecraftVersion,
           port: PORT
-        }, function (err, results) {
-          if (err) return done(err)
-          assert.ok(results.latency >= 0)
-          assert.ok(results.latency <= 1000)
-          delete results.latency
-          delete results.favicon // too lazy to figure it out
-          /*        assert.deepEqual(results, {
-           version: {
-           name: '1.7.4',
-           protocol: 4
-           },
-           description: { text: "test1234" }
-           }); */
-          done()
         })
+        assert.ok(results.latency >= 0)
+        assert.ok(results.latency <= 1000)
+        delete results.latency
+        delete results.favicon // too lazy to figure it out
+        /*        assert.deepEqual(results, {
+         version: {
+         name: '1.7.4',
+         protocol: 4
+         },
+         description: { text: "test1234" }
+         }); */
       })
 
       // chat/Style.java


### PR DESCRIPTION
## Problem

The `client <version>v > offline > pings the server` test fails intermittently on CI with:

```
Error: Connection closed before the server sent a status response
    at Client.<anonymous> (src/ping.js:47:14)
```

It hit three unrelated 26.1 runs in the last three days (the mocha 12 dependabot bump, #1521, and #1523). Before #1514 this case hung until the 120 s `closeTimeout` instead of failing fast, which is why it used to show up as a slow test rather than a red job.

## Cause

It's a startup race in vanilla that the test harness's readiness check exposes:

- minecraft-wrap resolves `startServer` as soon as the server logs the `Done (...)!` line, and the test pings immediately.
- Vanilla logs that line inside `DedicatedServer.initServer()`, but only builds its `ServerStatus` afterwards in `MinecraftServer.runServer()` (after also stat'ing the favicon).
- Since 1.19.4, `ServerHandshakePacketListenerImpl.handleIntention` runs on the Netty thread and, for a STATUS intent while `getStatus()` is still null, calls `connection.disconnect(IGNORE_STATUS_REASON)`. In the status state that is a bare socket close with no packet.

In the failing logs the ping lands within the same millisecond as `started server`; in passing runs there is ~90 ms of slack.

## Fix

Only the ping test is affected (the login path does not check the status object), so the test now retries that specific error for a bounded number of attempts with a short delay, instead of pinging exactly once. Any other error, or exhausting the attempts, still fails the test. `src/ping.js` is unchanged.

Verified locally: the 26.1 test passes under Java 25, and against a fake server that closes the first three status requests after the handshake the helper recovers, while against one that always closes it gives up with the original error after the configured attempts.
