### PR TITLE
fix: send a command with no signable argument as chat_command

### DIFF
--- a/src/client/chat.js
+++ b/src/client/chat.js
@@ -413,16 +413,18 @@ module.exports = function (client, options) {
       if (mcData.supportFeature('useChatSessions')) { // 1.19.3+
         const { acknowledged, acknowledgements } = getAcknowledgements()
         const canSign = client.profileKeys && client._session
+        const argumentSignatures = canSign ? signaturesForCommand(command, options.timestamp, options.salt, options.preview, acknowledgements) : []
         const chatPacket = {
           command,
           timestamp: options.timestamp,
           salt: options.salt,
-          argumentSignatures: canSign ? signaturesForCommand(command, options.timestamp, options.salt, options.preview, acknowledgements) : [],
+          argumentSignatures,
           messageCount: client._lastSeenMessages.pending,
           checksum: computeChatChecksum(client._lastSeenMessages), // 1.21.5+
           acknowledged
         }
-        client.write((mcData.supportFeature('seperateSignedChatCommandPacket') && canSign) ? 'chat_command_signed' : 'chat_command', chatPacket)
+        // A command with nothing to sign goes as the unsigned chat_command whether or not the client can sign.
+        client.write((mcData.supportFeature('seperateSignedChatCommandPacket') && argumentSignatures.length > 0) ? 'chat_command_signed' : 'chat_command', chatPacket)
         client._lastSeenMessages.pending = 0
       } else {
         client.write('chat_command', {

--- a/test/declareCommandsTest.js
+++ b/test/declareCommandsTest.js
@@ -54,4 +54,61 @@ describe('declare_commands handling', () => {
     assert.strictEqual(writes[0].name, 'chat_command_signed')
     assert.deepStrictEqual(writes[0].data.argumentSignatures.map(sig => sig.argumentName), ['message'])
   })
+
+  it('sends a command with no signable argument as the unsigned packet', () => {
+    const client = new EventEmitter()
+    client.version = '26.1'
+    client.verifyMessage = () => true
+    client.profileKeys = true
+    client._session = { uuid: '00000000-0000-0000-0000-000000000000' }
+
+    const writes = []
+    client.write = (name, data) => writes.push({ name, data })
+
+    injectChatPlugin(client, {})
+    client.signMessage = () => Buffer.from([1])
+
+    client.emit('declare_commands', {
+      rootIndex: 0,
+      nodes: [
+        { children: [1] },
+        { children: [2], extraNodeData: { name: 'msg' } },
+        { children: [], extraNodeData: { name: 'message', parser: 'minecraft:message' } }
+      ]
+    })
+
+    client._signedChat('/login hunter2', { timestamp: 1n, salt: 1n })
+
+    assert.strictEqual(writes.length, 1)
+    assert.strictEqual(writes[0].name, 'chat_command')
+    assert.deepStrictEqual(writes[0].data.argumentSignatures, [])
+  })
+
+  it('sends a known command without arguments as the unsigned packet', () => {
+    const client = new EventEmitter()
+    client.version = '26.1'
+    client.verifyMessage = () => true
+    client.profileKeys = true
+    client._session = { uuid: '00000000-0000-0000-0000-000000000000' }
+
+    const writes = []
+    client.write = (name, data) => writes.push({ name, data })
+
+    injectChatPlugin(client, {})
+    client.signMessage = () => Buffer.from([1])
+
+    client.emit('declare_commands', {
+      rootIndex: 0,
+      nodes: [
+        { children: [1] },
+        { children: [2], extraNodeData: { name: 'msg' } },
+        { children: [], extraNodeData: { name: 'message', parser: 'minecraft:message' } }
+      ]
+    })
+
+    client._signedChat('/msg', { timestamp: 1n, salt: 1n })
+
+    assert.strictEqual(writes.length, 1)
+    assert.strictEqual(writes[0].name, 'chat_command')
+  })
 })


### PR DESCRIPTION
Constraints on the serverbound command packet:

- `chat_command_signed` is written only when the command produced at least one argument signature.
- A command with no signable argument (`/login`, `/list`, anything the server's command tree does not mark as a message argument) is written as `chat_command`, whether or not the client can sign.
- The signature list carried by the packet is the one the command produced.

Vanilla reference: `ClientPacketListener.sendCommand` sends the unsigned `ServerboundChatCommandPacket` when `SignableCommand.of(...).arguments()` is empty.

Tests: `/login hunter2` and an argumentless `/msg` write `chat_command` with an empty signature list. Both fail on master and pass with the change. They do not run in CI yet; #1526 makes this file run and #1527 fixes the pre-existing test in it.