### PR TITLE
test: give the declare_commands tree the packet's rootIndex

### DIFF
--- a/test/declareCommandsTest.js
+++ b/test/declareCommandsTest.js
@@ -41,6 +41,7 @@ describe('declare_commands handling', () => {
     client.signMessage = () => Buffer.from([1])
 
     client.emit('declare_commands', {
+      rootIndex: 0,
       nodes: [
         { children: [1] },
         { children: [2], extraNodeData: { name: 'msg' } },


### PR DESCRIPTION
The `declare_commands` packet carries `nodes` and `rootIndex`. The tree this test emits has no `rootIndex`, so the client reads `nodes[undefined]`, rejects the tree and ends the connection, and the assertion never runs.

Invariant: a `declare_commands` packet built by a test names its root, so the client accepts the tree.

The test has failed since it was added. CI does not report it: `mochaTest` is invoked with `-g <version>v` and no name in this file carries a Minecraft version, so the file never runs. #1526 removes that filter.